### PR TITLE
release 0.0.3.alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.3.alpha
+
+- support `GET https://api.calendly.com/scheduled_events` API
+- support `GET https://api.calendly.com/scheduled_events/{uuid}` API
+
 # 0.0.2.alpha
 
 - support `GET https://api.calendly.com/event_types` API

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ As of now the supported statuses each Calendly API are as below.
   - [ ] Remove a User from an Organization
   - [ ] Revoke Organization Invitation
 - Organization
-  - [ ] Get Event
+  - [x] Get Event
   - [ ] Get Invitee of an Event
   - [ ] Get List of Event Invitees
-  - [ ] Get List of User Events
+  - [x] Get List of User Events
 - Webhook V2
   - These endpoints havn't been released yet.
 
@@ -56,12 +56,13 @@ Or install it yourself as:
 ## Usage
 
 The APIs client needs access token.
+This client setup step is below.
 
 ```ruby
 # set token by Calendly.configure methods.
 Calendly.configure do |config|
   config.token            = '<ACCESS_TOKEN>'
-  # follows are options. you can refresh access token if set it.
+  # follows are options. you can refresh access token if these are set.
   config.client_id        = '<CLIENT_ID>'
   config.client_secret    = '<CLIENT_SECRET>'
   config.refresh_token    = '<REFRESH_ACCESS_TOKEN>'
@@ -69,13 +70,16 @@ Calendly.configure do |config|
 end
 client = Calendly::Client.new
 
+
 # set token by Calendly::Client initializer.
 client = Calendly::Client.new '<ACCESS_TOKEN>'
 ```
 
+This client basic usage is below.
+
 ```ruby
 # get a current user's information.
-me = client.current_user
+me = client.me
 # => <Calendly::User uuid:U123456789>
 me.scheduling_url
 # => "https://calendly.com/your_name"
@@ -85,6 +89,17 @@ event_types, next_params = client.event_types me.uri
 # => [[#<Calendly::EventType uuid:ET001>, #<Calendly::EventType uuid:ET002>, #<Calendly::EventType uuid:ET003>], nil]
 event_types.first.scheduling_url
 # => "https://calendly.com/your_name/30min"
+
+# get scheduled events
+events, next_params = client.events me.uri
+# => => [[#<Calendly::Event uuid:EV001>, #<Calendly::Event uuid:EV002>, #<Calendly::Event uuid:EV003>], nil]
+ev = events.first
+ev.name
+# => "FooBar Meeting"
+ev.start_time
+# => 2020-07-22 01:30:00 UTC
+ev.end_time
+# => 2020-07-22 02:00:00 UTC
 ```
 
 ## Contributing

--- a/calendly.gemspec
+++ b/calendly.gemspec
@@ -28,14 +28,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'oauth2', '~> 1.4.4'
-  spec.add_runtime_dependency 'zeitwerk', '~> 2.3.0'
+  spec.add_runtime_dependency 'oauth2', '>= 1.4.4'
+  spec.add_runtime_dependency 'zeitwerk', '>= 2.3.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'codecov', '~> 0.1.17'
-  spec.add_development_dependency 'minitest', '~> 5.14.0'
-  spec.add_development_dependency 'minitest-reporters', '~> 1.4.2'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'simplecov', '~> 0.18.5'
-  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'codecov'
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'webmock'
 end

--- a/calendly.gemspec
+++ b/calendly.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday_middleware', '~> 1.0.0'
   spec.add_runtime_dependency 'oauth2', '~> 1.4.4'
   spec.add_runtime_dependency 'zeitwerk', '~> 2.3.0'
 

--- a/lib/calendly.rb
+++ b/lib/calendly.rb
@@ -7,8 +7,6 @@ loader.setup
 
 # module for Calendly apis client
 module Calendly
-  class Error < StandardError
-  end
   class << self
     def configure
       yield configuration

--- a/lib/calendly/api_error.rb
+++ b/lib/calendly/api_error.rb
@@ -2,29 +2,40 @@
 
 module Calendly
   # Calendly apis client error object.
-  class ApiError < StandardError
+  class ApiError < Calendly::Error
     # @return [Faraday::Response]
     attr_reader :response
     # @return [Integer]
     attr_reader :status
     # @return [String]
     attr_reader :title
-    # @return [String]
-    attr_reader :message
+    # @return [OAuth2::Error, JSON::ParserError]
+    attr_reader :cause_exception
 
-    def initialize(response)
+    def initialize(response, cause_exception)
       @response = response
-      @status = response.status
-      parsed = response.parsed
-      return unless parsed
-
-      @title = parsed['title']
-      @message = parsed['message']
+      @cause_exception = cause_exception
+      set_attributes_from_response
+      @message ||= cause_exception.message if cause_exception
       super @message
     end
 
     def inspect
       "\#<#{self.class}:#{object_id} title:#{title}, status:#{status}>"
+    end
+
+    private
+
+    def set_attributes_from_response
+      return unless response
+      return unless response.respond_to? :body
+
+      @status = response.status if response.respond_to? :status
+      parsed = JSON.parse response.body, symbolize_names: true
+      @title = parsed[:title]
+      @message = parsed[:message]
+    rescue JSON::ParserError
+      nil
     end
   end
 end

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'oauth2'
-require 'faraday_middleware'
 
 module Calendly
   # Calendly apis client.
@@ -11,12 +10,11 @@ module Calendly
 
     # @param [String] token a Calendly's access token.
     def initialize(token = nil)
-      @logger = Calendly.configuration.logger
+      @config = Calendly.configuration
+      @logger = @config.logger
       @token = token || Calendly.configuration.token
-      if @token.nil? || @token.to_s.empty?
-        raise Calendly::Error, 'token is required.'
-      end
 
+      check_not_empty @token, 'token'
       check_token
     end
 
@@ -28,13 +26,12 @@ module Calendly
     def access_token
       return @access_token if defined?(@access_token)
 
-      config = Calendly.configuration
-      client = OAuth2::Client.new(config.client_id,
-                                  config.client_secret, client_options)
+      client = OAuth2::Client.new(@config.client_id,
+                                  @config.client_secret, client_options)
       @access_token = OAuth2::AccessToken.new(
         client, @token,
-        refresh_token: config.refresh_token,
-        expires_at: config.token_expires_at
+        refresh_token: @config.refresh_token,
+        expires_at: @config.token_expires_at
       )
     end
 
@@ -47,6 +44,8 @@ module Calendly
       user
     end
 
+    alias me current_user
+
     #
     # Get basic information about a user
     #
@@ -54,6 +53,7 @@ module Calendly
     # @return [Calendly::User]
     # @since 0.0.1
     def user(uuid = 'me')
+      check_not_empty uuid, 'uuid'
       body = request :get, "users/#{uuid}"
       User.new body[:resource]
     end
@@ -65,54 +65,118 @@ module Calendly
     # @param [Hash] opts the optional request parameters.
     # @option opts [Integer] :count Number of rows to return.
     # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort  Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Array<Calendly::EventType>, Hash>]
     #  - [Array<Calendly::EventType>] event_types
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @since 0.0.2
     def event_types(user_uri, opts = {})
+      check_not_empty user_uri, 'user_uri'
+
+      opts_keys = %i[count page_token sort]
       params = { user: user_uri }
-      if opts.is_a? Hash
-        opts.transform_keys!(&:to_sym)
-        params.merge!(opts.slice(:count, :page_token, :sort))
-      end
+      params = merge_options opts, opts_keys, params
       body = request :get, 'event_types', params
+
       items = body[:collection] || []
       ev_types = items.map { |item| EventType.new item }
       [ev_types, next_page_params(body)]
     end
 
+    #
+    # Returns a single Event by its URI.
+    #
+    # @param [String] uuid the unique ScheduledEvent's id
+    # @return [Calendly::Event]
+    # @since 0.0.3
+    def event(uuid)
+      check_not_empty uuid, 'uuid'
+      body = request :get, "scheduled_events/#{uuid}"
+      Event.new body[:resource]
+    end
+
+    #
+    # Get List of User Events
+    #
+    # @param [String] user_uri Returns all events for a User who is assigned as event publisher.
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email
+    # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Whether the scheduled event is active or canceled
+    # @return [Array<Array<Calendly::Event>, Hash>]
+    #  - [Array<Calendly::Event>] events
+    #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
+    # @since 0.0.3
+    def events(user_uri, opts = {})
+      check_not_empty user_uri, 'user_uri'
+
+      opts_keys = %i[count invitee_email max_start_time min_start_time page_token sort status]
+      params = { user: user_uri }
+      params = merge_options opts, opts_keys, params
+      body = request :get, 'scheduled_events', params
+
+      items = body[:collection] || []
+      evs = items.map { |item| Event.new item }
+      [evs, next_page_params(body)]
+    end
+
     private
 
     def request(method, path, params = {})
-      @logger.debug "Request #{method.to_s.upcase} #{API_HOST}/#{path} params:#{params}"
+      debug_log "Request #{method.to_s.upcase} #{API_HOST}/#{path} params:#{params}"
       opts = { params: params }
       res = access_token.request(method, path, opts)
-      @logger.debug "Response status:#{res.status}, body:#{res.body}"
-      res.parsed
+      debug_log "Response status:#{res.status}, body:#{res.body}"
+      JSON.parse res.body, symbolize_names: true
     rescue OAuth2::Error => e
-      raise ApiError, e.response
+      res = e.response.response
+      raise ApiError.new res, e
+    rescue JSON::ParserError => e
+      raise ApiError.new res, e
     end
 
-    def client_options
-      faraday_build_proc = proc { |builder|
-        builder.response(:json, parser_options: { symbolize_names: true },
-                                content_type: /\bjson$/)
-      }
-      {
-        site: API_HOST,
-        authorize_url: "#{AUTH_API_HOST}/oauth/authorize",
-        token_url: "#{AUTH_API_HOST}/oauth/token",
-        connection_build: faraday_build_proc
-      }
+    def debug_log(msg)
+      return if @logger.nil?
+
+      @logger.debug msg
+    end
+
+    def check_not_empty(value, name)
+      raise Calendly::Error, "#{name} is required." if blank? value
+    end
+
+    def blank?(value)
+      return true if value.nil?
+      return true if value.to_s.empty?
+
+      false
     end
 
     def check_token
       refresh! if access_token.expired?
     end
 
+    def client_options
+      {
+        site: API_HOST,
+        authorize_url: "#{AUTH_API_HOST}/oauth/authorize",
+        token_url: "#{AUTH_API_HOST}/oauth/token"
+      }
+    end
+
     def refresh!
       @access_token = access_token.refresh!
+    end
+
+    def merge_options(opts, filters, params = {})
+      return params unless opts.is_a? Hash
+
+      permitted_opts = opts.transform_keys(&:to_sym).slice(*filters)
+      params.merge permitted_opts
     end
 
     def next_page_params(body)

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -9,7 +9,7 @@ module Calendly
     API_HOST = 'https://api.calendly.com'
     AUTH_API_HOST = 'https://auth.calendly.com'
 
-    # @param token [String] a Calendly's access token.
+    # @param [String] token a Calendly's access token.
     def initialize(token = nil)
       @logger = Calendly.configuration.logger
       @token = token || Calendly.configuration.token
@@ -24,19 +24,15 @@ module Calendly
     # Get access token object
     #
     # @return [OAuth2::AccessToken]
-    #
+    # @since 0.0.1
     def access_token
       return @access_token if defined?(@access_token)
 
       config = Calendly.configuration
-      client = OAuth2::Client.new(
-        config.client_id,
-        config.client_secret,
-        client_options
-      )
+      client = OAuth2::Client.new(config.client_id,
+                                  config.client_secret, client_options)
       @access_token = OAuth2::AccessToken.new(
-        client,
-        @token,
+        client, @token,
         refresh_token: config.refresh_token,
         expires_at: config.token_expires_at
       )
@@ -54,7 +50,7 @@ module Calendly
     #
     # Get basic information about a user
     #
-    # @param uuid [String] User unique identifier, or the constant "me" to reference the caller
+    # @param [String] uuid User unique identifier, or the constant "me" to reference the caller
     # @return [Calendly::User]
     # @since 0.0.1
     def user(uuid = 'me')
@@ -64,35 +60,26 @@ module Calendly
 
     #
     # Returns all Event Types associated with a specified User.
-    # GET https://api.calendly.com/event_types
     #
-    # @param user_uri [String] View event types available for the specified user (user URI).
-    # @param options [Hash] the optional request parameters
-    # @param options :count [String] Number of rows to return.
-    # @param options :page_token [String] Pass this to get the next portion of collection.
-    # @param options :sort [String] Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
-    # @return [event_types, next_params]
-    #  - event_types [Array<Calendly::EventType>]
-    #  - next_params [Hash]
-    #
+    # @param [String] user_uri View event types available for the specified user (user URI).
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort  Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
+    # @return [Array<Array<Calendly::EventType>, Hash>]
+    #  - [Array<Calendly::EventType>] event_types
+    #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @since 0.0.2
-    def event_types(user_uri, options = {})
+    def event_types(user_uri, opts = {})
       params = { user: user_uri }
-      if options.is_a? Hash
-        options.transform_keys!(&:to_sym)
-        params.merge!(sort: options[:sort]) if options[:sort]
-        params.merge!(count: options[:count]) if options[:count]
-        params.merge!(page_token: options[:page_token]) if options[:page_token]
+      if opts.is_a? Hash
+        opts.transform_keys!(&:to_sym)
+        params.merge!(opts.slice(:count, :page_token, :sort))
       end
       body = request :get, 'event_types', params
       items = body[:collection] || []
       ev_types = items.map { |item| EventType.new item }
-      if body[:pagination][:next_page]
-        next_page_query = URI.parse(body[:pagination][:next_page]).query
-        next_page_params = Hash[URI.decode_www_form(next_page_query)]
-        next_page_params.transform_keys!(&:to_sym)
-      end
-      [ev_types, next_page_params]
+      [ev_types, next_page_params(body)]
     end
 
     private
@@ -109,11 +96,8 @@ module Calendly
 
     def client_options
       faraday_build_proc = proc { |builder|
-        builder.response(
-          :json,
-          parser_options: { symbolize_names: true },
-          content_type: /\bjson$/
-        )
+        builder.response(:json, parser_options: { symbolize_names: true },
+                                content_type: /\bjson$/)
       }
       {
         site: API_HOST,
@@ -129,6 +113,15 @@ module Calendly
 
     def refresh!
       @access_token = access_token.refresh!
+    end
+
+    def next_page_params(body)
+      return unless body[:pagination]
+      return unless body[:pagination][:next_page]
+
+      uri = URI.parse body[:pagination][:next_page]
+      params = Hash[URI.decode_www_form(uri.query)]
+      params.transform_keys(&:to_sym)
     end
   end
 end

--- a/lib/calendly/error.rb
+++ b/lib/calendly/error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Calendly
+  # calendly module's base error object
+  class Error < StandardError
+    def initialize(message = nil)
+      @logger = Calendly.configuration.logger
+      log "#{self.class} occured. message:#{message}"
+      super message
+    end
+
+    private
+
+    def log(msg, level = :warn)
+      return if @logger.nil?
+
+      @logger.send level, msg
+    end
+  end
+end

--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Calendly
+  # Calendly's event model.
+  # A meeting that has been scheduled
+  class Event
+    include ModelUtils
+    UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/(\w+)\z}.freeze
+    TIME_FIELDS = %i[start_time end_time created_at updated_at].freeze
+
+    # @return [String]
+    # unique id of the Event object.
+    attr_accessor :uuid
+    # @return [String]
+    # Canonical resource reference.
+    attr_accessor :uri
+    # @return [String]
+    # Name of the event.
+    attr_accessor :name
+    # @return [String]
+    # Whether the event is active or canceled.
+    attr_accessor :status
+    # @return [Time]
+    # Moment when event is (or was) scheduled to begin
+    attr_accessor :start_time
+    # @return [Time]
+    # Moment when event is (or was) scheduled to end.
+    attr_accessor :end_time
+    # @return [String]
+    # Reference to Event Type uri associated with this event
+    attr_accessor :event_type
+    # @return [String]
+    # Reference to Event Type uuid associated with this event
+    attr_accessor :event_type_uuid
+    # @return [Time]
+    # Moment when user record was first created.
+    attr_accessor :created_at
+    # @return [Time]
+    # Moment when user record was last updated.
+    attr_accessor :updated_at
+
+    # @return [Calendly::Location]
+    attr_accessor :location
+
+    # @return [Integer]
+    attr_accessor :invitees_counter_total
+    # @return [Integer]
+    attr_accessor :invitees_counter_active
+    # @return [Integer]
+    attr_accessor :invitees_counter_limit
+
+    private
+
+    def after_set_attributes(attrs)
+      super attrs
+      @event_type_uuid = EventType.extract_uuid event_type if event_type
+
+      loc_params = attrs[:location]
+      @location = Location.new loc_params if loc_params&.is_a? Hash
+
+      inv_cnt_params = attrs[:invitees_counter]
+      if inv_cnt_params&.is_a? Hash
+        @invitees_counter_total = inv_cnt_params[:total]
+        @invitees_counter_active = inv_cnt_params[:active]
+        @invitees_counter_limit = inv_cnt_params[:limit]
+      end
+
+      true
+    end
+  end
+end

--- a/lib/calendly/models/event_type.rb
+++ b/lib/calendly/models/event_type.rb
@@ -5,11 +5,11 @@ module Calendly
   # A configuration for a schedulable event
   class EventType
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/event_types/(.*)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/event_types/(\w+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
 
     # @return [String]
-    # unique id of EventType object.
+    # unique id of the EventType object.
     attr_accessor :uuid
     # @return [String]
     # Canonical resource reference.
@@ -76,12 +76,14 @@ module Calendly
 
     def after_set_attributes(attrs)
       super attrs
-      return unless attrs[:profile]
+      if attrs[:profile]
 
-      @owner_uri = attrs[:profile][:owner]
-      @owner_uuid = User.extract_uuid @owner_uri
-      @owner_name = attrs[:profile][:name]
-      @owner_type = attrs[:profile][:type]
+        @owner_uri = attrs[:profile][:owner]
+        @owner_uuid = User.extract_uuid owner_uri
+        @owner_name = attrs[:profile][:name]
+        @owner_type = attrs[:profile][:type]
+      end
+      true
     end
   end
 end

--- a/lib/calendly/models/location.rb
+++ b/lib/calendly/models/location.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Calendly
+  # Calendly's location model.
+  # Polymorphic base type for the various supported meeting locations.
+  class Location
+    include ModelUtils
+
+    # data patterns is below:
+    # - 1. A meeting at a pre-specified physical location
+    #  - [String] :kind
+    #  - [String] :location A physical location specified by the meeting publisher.
+    # - 2. Meeting publisher will call the invitee
+    #  - [String] :kind
+    # - 3. Invitee will call meeting publisher at the specified phone number.
+    #  - [String] :kind
+    #  - [String] :phone_number Phone number invitee should use to reach meeting publisher.
+    # - 4. Meeting will take place in a Google Meet / Hangout conference.
+    #  - [String] :kind
+    # - 5. Meeting will take place in a Zoom conference.
+    #  - [String] :kind
+    # - 6. Meeting will take place in a GotoMeeting conference.
+    #  - [String] :kind
+    #  - [String] :external_id Zoom-supplied conference id.
+    #  - [String] :state Current state of the conference in Zoom.
+    #  - [Hash] :data Arbitrary conference metadata supplied by Zoom.
+    # - 7. Arbitrary conference metadata supplied by GotoMeeting.
+    #  - [String] :kind
+    #  - [String] :external_id GotoMeeting-supplied conference id.
+    #  - [String] :state Current state of the conference in GotoMeeting.
+    #  - [String] :data Arbitrary conference metadata supplied by GotoMeeting.
+    # - 8. Meeting location does not fall in a standard category, and is as described by the meeting publisher.
+    #  - [String] :kind
+    #  - [String] :location Location description provided by meeting publisher.
+    # - 9. Meeting location was specified by invitee.
+    #  - [String] :kind
+    #  - [String] :location Meeting location was specified by invitee.
+    #
+
+    # @return [String]
+    attr_accessor :kind
+    # @return [String]
+    attr_accessor :location
+    # @return [String]
+    attr_accessor :phone_number
+    # @return [String]
+    attr_accessor :external_id
+    # @return [String]
+    attr_accessor :state
+    # @return [Hash]
+    attr_accessor :data
+  end
+end

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -15,6 +15,7 @@ module Calendly
     end
 
     module ClassMethods
+      DEFAULT_UUID_RE_INDEX = 1
       def extract_uuid(str)
         return unless defined? self::UUID_RE
         return unless str
@@ -23,7 +24,9 @@ module Calendly
         m = self::UUID_RE.match str
         return if m.nil?
 
-        m[1]
+        index = self::UUID_RE_INDEX if defined? self::UUID_RE_INDEX
+        index ||= DEFAULT_UUID_RE_INDEX
+        m[index]
       end
     end
 
@@ -47,11 +50,11 @@ module Calendly
         instance_variable_set "@#{key}", value
       end
       after_set_attributes(attrs)
-      true
     end
 
     def after_set_attributes(attrs)
       @uuid = self.class.extract_uuid(attrs[:uri]) if respond_to? :uuid=
+      true
     end
   end
 end

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Calendly
+  class Organization
+    include ModelUtils
+    API_URL = "#{Client::API_HOST}/organization/"
+    TIME_FIELDS = %i[created_at updated_at].freeze
+  end
+end

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Calendly
-  class Organization
-    include ModelUtils
-    API_URL = "#{Client::API_HOST}/organization/"
-    TIME_FIELDS = %i[created_at updated_at].freeze
-  end
-end

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -5,11 +5,11 @@ module Calendly
   # Primary account details of a specific user.
   class User
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/users/(.*)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/users/(\w+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
 
     # @return [String]
-    # unique id of User object.
+    # unique id of the User object.
     attr_accessor :uuid
     # @return [String]
     # Canonical resource reference.

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,3 +1,3 @@
 module Calendly
-  VERSION = "0.0.2.alpha"
+  VERSION = "0.0.3.alpha"
 end

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -12,8 +12,8 @@ module AssertHelper
     assert_equal 'https://foobar.cloudfront.net/uploads/user/avatar/foobar/foobar.gif', user.avatar_url
     assert_equal 'https://calendly.com/foobar', user.scheduling_url
     assert_equal 'Asia/Tokyo', user.timezone
-    assert_equal Time.parse('2020-05-01T00:00:00.000Z').to_i, user.created_at.to_i
-    assert_equal Time.parse('2020-05-02T00:00:00.000Z').to_i, user.updated_at.to_i
+    assert_equal Time.parse('2020-05-01T00:00:00.000000Z').to_i, user.created_at.to_i
+    assert_equal Time.parse('2020-05-02T00:00:00.000000Z').to_i, user.updated_at.to_i
   end
 
   def assert_event_type001(ev_type)
@@ -25,14 +25,14 @@ module AssertHelper
     assert_equal 15, ev_type.duration
     assert_nil ev_type.internal_note
     assert_equal 'solo', ev_type.kind
-    assert_equal '15 Minutes Meeting', ev_type.name
+    assert_equal '15 Minute Meeting', ev_type.name
     assert_nil ev_type.pooling_type
     assert_equal 'https://calendly.com/foobar/15min', ev_type.scheduling_url
     assert_equal '15min', ev_type.slug
     assert_equal 'StandardEventType', ev_type.type
     assert_equal 'https://api.calendly.com/event_types/ET0001', ev_type.uri
-    assert_equal Time.parse('2020-07-01T03:00:00.000Z').to_i, ev_type.created_at.to_i
-    assert_equal Time.parse('2020-07-11T03:00:00.000Z').to_i, ev_type.updated_at.to_i
+    assert_equal Time.parse('2020-07-01T03:00:00.000000Z').to_i, ev_type.created_at.to_i
+    assert_equal Time.parse('2020-07-11T03:00:00.000000Z').to_i, ev_type.updated_at.to_i
     assert_equal 'U12345678', ev_type.owner_uuid
     assert_equal 'User', ev_type.owner_type
     assert_equal 'FooBar', ev_type.owner_name
@@ -48,14 +48,14 @@ module AssertHelper
     assert_equal 60, ev_type.duration
     assert_equal 'foo bar notes', ev_type.internal_note
     assert_equal 'solo', ev_type.kind
-    assert_equal '60 Minutes Meeting', ev_type.name
+    assert_equal '60 Minute Meeting', ev_type.name
     assert_nil ev_type.pooling_type
     assert_equal 'https://calendly.com/foobar/60min', ev_type.scheduling_url
     assert_equal '60min', ev_type.slug
     assert_equal 'StandardEventType', ev_type.type
     assert_equal 'https://api.calendly.com/event_types/ET0002', ev_type.uri
-    assert_equal Time.parse('2020-07-02T03:00:00.000Z').to_i, ev_type.created_at.to_i
-    assert_equal Time.parse('2020-07-12T03:00:00.000Z').to_i, ev_type.updated_at.to_i
+    assert_equal Time.parse('2020-07-02T03:00:00.000000Z').to_i, ev_type.created_at.to_i
+    assert_equal Time.parse('2020-07-12T03:00:00.000000Z').to_i, ev_type.updated_at.to_i
     assert_equal 'U12345678', ev_type.owner_uuid
     assert_equal 'User', ev_type.owner_type
     assert_equal 'FooBar', ev_type.owner_name
@@ -71,17 +71,68 @@ module AssertHelper
     assert_equal 30, ev_type.duration
     assert_nil ev_type.internal_note
     assert_equal 'group', ev_type.kind
-    assert_equal '30 Minutes Meeting', ev_type.name
+    assert_equal '30 Minute Meeting', ev_type.name
     assert_nil ev_type.pooling_type
     assert_equal 'https://calendly.com/foobar/30min', ev_type.scheduling_url
     assert_equal '30min', ev_type.slug
     assert_equal 'StandardEventType', ev_type.type
     assert_equal 'https://api.calendly.com/event_types/ET0003', ev_type.uri
-    assert_equal Time.parse('2020-07-03T03:00:00.000Z').to_i, ev_type.created_at.to_i
-    assert_equal Time.parse('2020-07-13T03:00:00.000Z').to_i, ev_type.updated_at.to_i
+    assert_equal Time.parse('2020-07-03T03:00:00.000000Z').to_i, ev_type.created_at.to_i
+    assert_equal Time.parse('2020-07-13T03:00:00.000000Z').to_i, ev_type.updated_at.to_i
     assert_equal 'U12345678', ev_type.owner_uuid
     assert_equal 'User', ev_type.owner_type
     assert_equal 'FooBar', ev_type.owner_name
     assert_equal 'https://api.calendly.com/users/U12345678', ev_type.owner_uri
+  end
+
+  def assert_event001(ev)
+    assert_equal 'EV001', ev.uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV001', ev.uri
+    assert_equal '30 Minute Meeting', ev.name
+    assert_equal 'canceled', ev.status
+    assert_equal 'https://api.calendly.com/event_types/ET001', ev.event_type
+    assert_equal 'ET001', ev.event_type_uuid
+    assert_nil ev.location
+    assert_equal 1, ev.invitees_counter_total
+    assert_equal 0, ev.invitees_counter_active
+    assert_equal 5, ev.invitees_counter_limit
+    assert_equal Time.parse('2020-07-22T01:30:00.000000Z').to_i, ev.start_time.to_i
+    assert_equal Time.parse('2020-07-22T02:00:00.000000Z').to_i, ev.end_time.to_i
+    assert_equal Time.parse('2020-07-10T05:00:00.000000Z').to_i, ev.created_at.to_i
+    assert_equal Time.parse('2020-07-11T06:00:00.000000Z').to_i, ev.updated_at.to_i
+  end
+
+  def assert_event002(ev)
+    assert_equal 'EV002', ev.uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV002', ev.uri
+    assert_equal '15 Minute Meeting', ev.name
+    assert_equal 'active', ev.status
+    assert_equal 'https://api.calendly.com/event_types/ET002', ev.event_type
+    assert_equal 'ET002', ev.event_type_uuid
+    assert_equal 'Tokyo', ev.location
+    assert_equal 1, ev.invitees_counter_total
+    assert_equal 1, ev.invitees_counter_active
+    assert_equal 1, ev.invitees_counter_limit
+    assert_equal Time.parse('2020-07-23T01:15:00.000000Z').to_i, ev.start_time.to_i
+    assert_equal Time.parse('2020-07-23T01:30:00.000000Z').to_i, ev.end_time.to_i
+    assert_equal Time.parse('2020-07-10T06:00:00.000000Z').to_i, ev.created_at.to_i
+    assert_equal Time.parse('2020-07-10T07:00:00.000000Z').to_i, ev.updated_at.to_i
+  end
+
+  def assert_event003(ev)
+    assert_equal 'EV003', ev.uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV003', ev.uri
+    assert_equal '60 Minute Meeting', ev.name
+    assert_equal 'active', ev.status
+    assert_equal 'https://api.calendly.com/event_types/ET003', ev.event_type
+    assert_equal 'ET003', ev.event_type_uuid
+    assert_nil ev.location
+    assert_equal 1, ev.invitees_counter_total
+    assert_equal 1, ev.invitees_counter_active
+    assert_equal 1, ev.invitees_counter_limit
+    assert_equal Time.parse('2020-07-24T01:15:00.000000Z').to_i, ev.start_time.to_i
+    assert_equal Time.parse('2020-07-24T02:15:00.000000Z').to_i, ev.end_time.to_i
+    assert_equal Time.parse('2020-07-13T06:00:00.000000Z').to_i, ev.created_at.to_i
+    assert_equal Time.parse('2020-07-13T07:00:00.000000Z').to_i, ev.updated_at.to_i
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,6 @@ if ENV['CI'] == 'true'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 require 'minitest/autorun'
-require 'minitest/reporters'
-Minitest::Reporters.use!
 require 'webmock/minitest'
 
 require 'calendly'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ class CalendlyBaseTest < Minitest::Test
 
   def default_response_headers
     {
-      'Content-Type' => 'application/json; charset=utf-8',
+      'Content-Type' => 'application/json; charset=utf-8'
     }
   end
 

--- a/test/testdata/event_types_001.json
+++ b/test/testdata/event_types_001.json
@@ -3,13 +3,13 @@
     {
       "active": true,
       "color": "#000001",
-      "created_at": "2020-07-01T03:00:00.000Z",
+      "created_at": "2020-07-01T03:00:00.000000Z",
       "description_html": null,
       "description_plain": null,
       "duration": 15,
       "internal_note": null,
       "kind": "solo",
-      "name": "15 Minutes Meeting",
+      "name": "15 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -19,19 +19,19 @@
       "scheduling_url": "https://calendly.com/foobar/15min",
       "slug": "15min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-11T03:00:00.000Z",
+      "updated_at": "2020-07-11T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0001"
     },
     {
       "active": false,
       "color": "#000002",
-      "created_at": "2020-07-02T03:00:00.000Z",
+      "created_at": "2020-07-02T03:00:00.000000Z",
       "description_html": null,
       "description_plain": null,
       "duration": 60,
       "internal_note": "foo bar notes",
       "kind": "solo",
-      "name": "60 Minutes Meeting",
+      "name": "60 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -41,19 +41,19 @@
       "scheduling_url": "https://calendly.com/foobar/60min",
       "slug": "60min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-12T03:00:00.000Z",
+      "updated_at": "2020-07-12T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0002"
     },
     {
       "active": false,
       "color": "#000003",
-      "created_at": "2020-07-03T03:00:00.000Z",
+      "created_at": "2020-07-03T03:00:00.000000Z",
       "description_html": "<p>description</p>",
       "description_plain": "description",
       "duration": 30,
       "internal_note": null,
       "kind": "group",
-      "name": "30 Minutes Meeting",
+      "name": "30 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -63,7 +63,7 @@
       "scheduling_url": "https://calendly.com/foobar/30min",
       "slug": "30min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-13T03:00:00.000Z",
+      "updated_at": "2020-07-13T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0003"
     }
   ],

--- a/test/testdata/event_types_002_page1.json
+++ b/test/testdata/event_types_002_page1.json
@@ -3,13 +3,13 @@
     {
       "active": false,
       "color": "#000003",
-      "created_at": "2020-07-03T03:00:00.000Z",
+      "created_at": "2020-07-03T03:00:00.000000Z",
       "description_html": "<p>description</p>",
       "description_plain": "description",
       "duration": 30,
       "internal_note": null,
       "kind": "group",
-      "name": "30 Minutes Meeting",
+      "name": "30 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -19,19 +19,19 @@
       "scheduling_url": "https://calendly.com/foobar/30min",
       "slug": "30min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-13T03:00:00.000Z",
+      "updated_at": "2020-07-13T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0003"
     },
     {
       "active": false,
       "color": "#000002",
-      "created_at": "2020-07-02T03:00:00.000Z",
+      "created_at": "2020-07-02T03:00:00.000000Z",
       "description_html": null,
       "description_plain": null,
       "duration": 60,
       "internal_note": "foo bar notes",
       "kind": "solo",
-      "name": "60 Minutes Meeting",
+      "name": "60 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -41,7 +41,7 @@
       "scheduling_url": "https://calendly.com/foobar/60min",
       "slug": "60min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-12T03:00:00.000Z",
+      "updated_at": "2020-07-12T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0002"
     }
   ],

--- a/test/testdata/event_types_002_page2.json
+++ b/test/testdata/event_types_002_page2.json
@@ -3,13 +3,13 @@
     {
       "active": true,
       "color": "#000001",
-      "created_at": "2020-07-01T03:00:00.000Z",
+      "created_at": "2020-07-01T03:00:00.000000Z",
       "description_html": null,
       "description_plain": null,
       "duration": 15,
       "internal_note": null,
       "kind": "solo",
-      "name": "15 Minutes Meeting",
+      "name": "15 Minute Meeting",
       "pooling_type": null,
       "profile": {
         "name": "FooBar",
@@ -19,7 +19,7 @@
       "scheduling_url": "https://calendly.com/foobar/15min",
       "slug": "15min",
       "type": "StandardEventType",
-      "updated_at": "2020-07-11T03:00:00.000Z",
+      "updated_at": "2020-07-11T03:00:00.000000Z",
       "uri": "https://api.calendly.com/event_types/ET0001"
     }
   ],

--- a/test/testdata/scheduled_event_001.json
+++ b/test/testdata/scheduled_event_001.json
@@ -1,0 +1,18 @@
+{
+  "resource": {
+    "created_at": "2020-07-10T05:00:00.000000Z",
+    "end_time": "2020-07-22T02:00:00.000000Z",
+    "event_type": "https://api.calendly.com/event_types/ET001",
+    "invitees_counter": {
+      "active": 0,
+      "limit": 5,
+      "total": 1
+    },
+    "location": null,
+    "name": "30 Minute Meeting",
+    "start_time": "2020-07-22T01:30:00.000000Z",
+    "status": "canceled",
+    "updated_at": "2020-07-11T06:00:00.000000Z",
+    "uri": "https://api.calendly.com/scheduled_events/EV001"
+  }
+}

--- a/test/testdata/scheduled_events_001.json
+++ b/test/testdata/scheduled_events_001.json
@@ -1,0 +1,40 @@
+{
+  "collection": [
+    {
+      "created_at": "2020-07-10T05:00:00.000000Z",
+      "end_time": "2020-07-22T02:00:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET001",
+      "invitees_counter": {
+        "active": 0,
+        "limit": 5,
+        "total": 1
+      },
+      "location": null,
+      "name": "30 Minute Meeting",
+      "start_time": "2020-07-22T01:30:00.000000Z",
+      "status": "canceled",
+      "updated_at": "2020-07-11T06:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV001"
+    },
+    {
+      "created_at": "2020-07-10T06:00:00.000000Z",
+      "end_time": "2020-07-23T01:30:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET002",
+      "invitees_counter": {
+        "active": 1,
+        "limit": 1,
+        "total": 1
+      },
+      "location": "Tokyo",
+      "name": "15 Minute Meeting",
+      "start_time": "2020-07-23T01:15:00.000000Z",
+      "status": "active",
+      "updated_at": "2020-07-10T07:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV002"
+    }
+  ],
+  "pagination": {
+    "count": 2,
+    "next_page": null
+  }
+}

--- a/test/testdata/scheduled_events_002_page1.json
+++ b/test/testdata/scheduled_events_002_page1.json
@@ -1,0 +1,40 @@
+{
+  "collection": [
+    {
+      "created_at": "2020-07-13T06:00:00.000000Z",
+      "end_time": "2020-07-24T02:15:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET003",
+      "invitees_counter": {
+        "active": 1,
+        "limit": 1,
+        "total": 1
+      },
+      "location": null,
+      "name": "60 Minute Meeting",
+      "start_time": "2020-07-24T01:15:00.000000Z",
+      "status": "active",
+      "updated_at": "2020-07-13T07:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV003"
+    },
+    {
+      "created_at": "2020-07-10T06:00:00.000000Z",
+      "end_time": "2020-07-23T01:30:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET002",
+      "invitees_counter": {
+        "active": 1,
+        "limit": 1,
+        "total": 1
+      },
+      "location": "Tokyo",
+      "name": "15 Minute Meeting",
+      "start_time": "2020-07-23T01:15:00.000000Z",
+      "status": "active",
+      "updated_at": "2020-07-10T07:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV002"
+    }
+  ],
+  "pagination": {
+    "count": 2,
+    "next_page": "https://api.calendly.com/scheduled_events?count=2&invitee_email=foobar%40example.com&max_start_time=2020-08-01T00%3A00%3A00.000000Z&min_start_time=2020-07-01T00%3A00%3A00.000000Z&page_token=NEXT_PAGE_TOKEN&status=active&user=https%3A%2F%2Fapi.calendly.com%2Fusers%2FU12345678"
+  }
+}

--- a/test/testdata/scheduled_events_002_page2.json
+++ b/test/testdata/scheduled_events_002_page2.json
@@ -1,0 +1,24 @@
+{
+  "collection": [
+    {
+      "created_at": "2020-07-10T05:00:00.000Z",
+      "end_time": "2020-07-22T02:00:00.000Z",
+      "event_type": "https://api.calendly.com/event_types/ET001",
+      "invitees_counter": {
+        "active": 0,
+        "limit": 5,
+        "total": 1
+      },
+      "location": null,
+      "name": "30 Minute Meeting",
+      "start_time": "2020-07-22T01:30:00.000Z",
+      "status": "canceled",
+      "updated_at": "2020-07-11T06:00:00.000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV001"
+    }
+  ],
+  "pagination": {
+    "count": 1,
+    "next_page": null
+  }
+}

--- a/test/testdata/user_001.json
+++ b/test/testdata/user_001.json
@@ -1,13 +1,13 @@
 {
   "resource": {
     "avatar_url": "https://foobar.cloudfront.net/uploads/user/avatar/foobar/foobar.gif",
-    "created_at": "2020-05-01T00:00:00.000Z",
+    "created_at": "2020-05-01T00:00:00.000000Z",
     "email": "foobar@example.com",
     "name": "FooBar",
     "scheduling_url": "https://calendly.com/foobar",
     "slug": "foobar",
     "timezone": "Asia/Tokyo",
-    "updated_at": "2020-05-02T00:00:00.000Z",
+    "updated_at": "2020-05-02T00:00:00.000000Z",
     "uri": "https://api.calendly.com/users/U12345678"
   }
 }


### PR DESCRIPTION
- support `GET https://api.calendly.com/scheduled_events` API
- support `GET https://api.calendly.com/scheduled_events/{uuid}` API
