### PR TITLE
release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.0
+
+- define methods to access associated resources with each model.
+- rename methods:
+  - `Calendly::Client#events` to `Calendly::Client#scheduled_events`
+
 # 0.0.7.alpha
 
 - support APIs

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ event_types.first.scheduling_url
 # => "https://calendly.com/your_name/30min"
 
 # get scheduled events
-events, next_params = client.events me.uri
+events, next_params = client.scheduled_events me.uri
 # => => [[#<Calendly::Event uuid:EV001>, #<Calendly::Event uuid:EV002>, #<Calendly::Event uuid:EV003>], nil]
 ev = events.first
 ev.name

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ me = client.me
 me.scheduling_url
 # => "https://calendly.com/your_name"
 
-# get event_types
-event_types, next_params = client.event_types me.uri
-# => [[#<Calendly::EventType uuid:ET001>, #<Calendly::EventType uuid:ET002>, #<Calendly::EventType uuid:ET003>], nil]
+# get all Event Types
+event_types = me.event_types
+# => [#<Calendly::EventType uuid:ET001>, #<Calendly::EventType uuid:ET002>, #<Calendly::EventType uuid:ET003>]
 event_types.first.scheduling_url
 # => "https://calendly.com/your_name/30min"
 
 # get scheduled events
-events, next_params = client.scheduled_events me.uri
-# => => [[#<Calendly::Event uuid:EV001>, #<Calendly::Event uuid:EV002>, #<Calendly::Event uuid:EV003>], nil]
+events = me.scheduled_events
+# => => [#<Calendly::Event uuid:EV001>, #<Calendly::Event uuid:EV002>, #<Calendly::Event uuid:EV003>]
 ev = events.first
 ev.name
 # => "FooBar Meeting"
@@ -100,6 +100,28 @@ ev.start_time
 # => 2020-07-22 01:30:00 UTC
 ev.end_time
 # => 2020-07-22 02:00:00 UTC
+
+# get organization information
+own_member = me.organization_membership
+# => #<Calendly::OrganizationMembership uuid:MEM001>
+my_org = own_member.organization
+all_members = my_org.memberships
+# => [#<Calendly::OrganizationMembership uuid:MEM001>, #<Calendly::OrganizationMembership uuid:MEM002>]
+
+# create new invitation and send invitation email
+invitation = my_org.create_invitation('foobar@example.com')
+# => #<Calendly::OrganizationInvitation uuid:INV001>
+invitation.status
+# => "pending"
+
+# cancel the invitation
+invitation.delete
+
+# if the log level set :debug, you can get the request/response information.
+Calendly.configuration.logger.level = :debug
+invitation = my_org.create_invitation('foobar@example.com')
+# D, [2020-08-10T10:48:15] DEBUG -- : Request POST https://api.calendly.com/organizations/ORG001/invitations params:, body:{:email=>"foobar@example.com"}
+# D, [2020-08-10T10:48:16] DEBUG -- : Response status:201, body:{"resource":{"created_at":"2020-08-10T10:48:16.051159Z","email":"foobar@example.com","last_sent_at":"2020-08-10T10:48:16.096518Z","organization":"https://api.calendly.com/organizations/ORG001","status":"pending","updated_at":"2020-08-10T10:48:16.051159Z","uri":"https://api.calendly.com/organizations/ORG001/invitations/INV001"}}
 ```
 
 ## Contributing

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -199,7 +199,7 @@ module Calendly
     # Returns information about a user's organization membership
     #
     # @param [String] uuid the specified membership (organization membership's uuid).
-    # @return [OrganizationMembership]
+    # @return [Calendly::OrganizationMembership]
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.5

--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -7,6 +7,7 @@ module Calendly
     include ModelUtils
     UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/(\w+)\z}.freeze
     TIME_FIELDS = %i[start_time end_time created_at updated_at].freeze
+    ASSOCIATION = { event_type: EventType }.freeze
 
     # @return [String]
     # unique id of the Event object.
@@ -33,16 +34,13 @@ module Calendly
     # Moment when user record was last updated.
     attr_accessor :updated_at
 
+    # @return [EventType]
+    # Reference to Event Type associated with this event.
+    attr_accessor :event_type
+
     # @return [Calendly::Location]
     # location in this event.
     attr_accessor :location
-
-    # @return [String]
-    # Reference to Event Type uri associated with this event.
-    attr_accessor :event_type_uri
-    # @return [String]
-    # Reference to Event Type uuid associated with this event.
-    attr_accessor :event_type_uuid
 
     # @return [Integer]
     # number of total invitees in this event.
@@ -87,13 +85,6 @@ module Calendly
 
     def after_set_attributes(attrs)
       super attrs
-      if attrs[:event_type]
-        ev_type_attrs = { uri: attrs[:event_type] }
-        event_type = EventType.new ev_type_attrs, @client
-        @event_type_uri = event_type.uri
-        @event_type_uuid = event_type.uuid
-      end
-
       loc_params = attrs[:location]
       @location = Location.new loc_params if loc_params&.is_a? Hash
 

--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -54,6 +54,35 @@ module Calendly
     # max invitees in this event.
     attr_accessor :invitees_counter_limit
 
+    #
+    # Get Scheduled Event associated with self.
+    #
+    # @return [Calendly::Event]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def fetch
+      client.scheduled_event uuid
+    end
+
+    #
+    # Returns all Event Invitees associated with self.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :email Filter by email.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Whether the scheduled event is active or canceled.
+    # @return [Array<Calendly::Invitee>]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def invitees(opts = {})
+      request_proc = proc { |options| client.event_invitees uuid, options }
+      auto_pagination request_proc, opts
+    end
+
     private
 
     def after_set_attributes(attrs)

--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -59,8 +59,8 @@ module Calendly
     def after_set_attributes(attrs)
       super attrs
       if attrs[:event_type]
-        ev_type_params = { uri: attrs[:event_type] }
-        event_type = EventType.new ev_type_params
+        ev_type_attrs = { uri: attrs[:event_type] }
+        event_type = EventType.new ev_type_attrs, @client
         @event_type_uri = event_type.uri
         @event_type_uuid = event_type.uuid
       end
@@ -68,14 +68,12 @@ module Calendly
       loc_params = attrs[:location]
       @location = Location.new loc_params if loc_params&.is_a? Hash
 
-      inv_cnt_params = attrs[:invitees_counter]
-      if inv_cnt_params&.is_a? Hash
-        @invitees_counter_total = inv_cnt_params[:total]
-        @invitees_counter_active = inv_cnt_params[:active]
-        @invitees_counter_limit = inv_cnt_params[:limit]
+      inv_cnt_attrs = attrs[:invitees_counter]
+      if inv_cnt_attrs&.is_a? Hash
+        @invitees_counter_total = inv_cnt_attrs[:total]
+        @invitees_counter_active = inv_cnt_attrs[:active]
+        @invitees_counter_limit = inv_cnt_attrs[:limit]
       end
-
-      true
     end
   end
 end

--- a/lib/calendly/models/event_type.rb
+++ b/lib/calendly/models/event_type.rb
@@ -83,7 +83,6 @@ module Calendly
         @owner_name = attrs[:profile][:name]
         @owner_type = attrs[:profile][:type]
       end
-      true
     end
   end
 end

--- a/lib/calendly/models/invitee.rb
+++ b/lib/calendly/models/invitee.rb
@@ -55,8 +55,8 @@ module Calendly
     def after_set_attributes(attrs)
       super attrs
       if attrs[:event]
-        event_params = { uri: attrs[:event] }
-        ev = Event.new event_params
+        event_attrs = { uri: attrs[:event] }
+        ev = Event.new event_attrs, @client
         @event_uri = ev.uri
         @event_uuid = ev.uuid
       end
@@ -67,8 +67,6 @@ module Calendly
 
       trac_attrs = attrs[:tracking]
       @tracking = InviteeTracking.new trac_attrs if trac_attrs&.is_a? Hash
-
-      true
     end
   end
 end

--- a/lib/calendly/models/invitee.rb
+++ b/lib/calendly/models/invitee.rb
@@ -6,7 +6,6 @@ module Calendly
   class Invitee
     include ModelUtils
     UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/\w+/invitees/(\w+)\z}.freeze
-
     TIME_FIELDS = %i[created_at updated_at].freeze
 
     # @return [String]
@@ -49,6 +48,18 @@ module Calendly
 
     # @return [Calendly::InviteeTracking]
     attr_accessor :tracking
+
+    #
+    # Get Event Invitee associated with self.
+    #
+    # @return [Calendly::Invitee]
+    # @raise [Calendly::Error] if the event_uuid is empty.
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def fetch
+      client.event_invitee event_uuid, uuid
+    end
 
     private
 

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -5,8 +5,35 @@ require 'time'
 module Calendly
   # Calendly model utility.
   module ModelUtils
-    def initialize(attrs = nil)
+    # @param [Hash] attrs the attributes of the model.
+    # @param [Calendly::Client] the api client.
+    def initialize(attrs = nil, client = nil)
+      @client = client
       set_attributes attrs
+    end
+
+    #
+    # Returns api client.
+    #
+    # @return [Calendly::Client]
+    # @raise [Calendly::Error] if the client is nil.
+    # @since 0.1.0
+    def client
+      raise Error, '@client is not ready.' unless @client
+
+      @client
+    end
+
+    #
+    # alias of uuid.
+    #
+    # @return [String]
+    # @raise [Calendly::Error] if uuid is not defined.
+    # @since 0.1.0
+    def id
+      raise Error, 'uuid is not defined.' unless defined? uuid
+
+      uuid
     end
 
     def inspect

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -90,8 +90,8 @@ module Calendly
     def auto_pagination(request_proc, opts)
       items = []
       loop do
-        event_types, next_opts = request_proc.call opts
-        items = [*items, *event_types]
+        new_items, next_opts = request_proc.call opts
+        items = [*items, *new_items]
         break unless next_opts
 
         opts = next_opts

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -68,7 +68,10 @@ module Calendly
       attrs.each do |key, value|
         next unless respond_to? "#{key}=".to_sym
 
-        if defined?(self.class::TIME_FIELDS) && self.class::TIME_FIELDS.include?(key)
+        if defined?(self.class::ASSOCIATION) && self.class::ASSOCIATION.key?(key)
+          associated_attrs = value.is_a?(Hash) ? value : { uri: value }
+          value = self.class::ASSOCIATION[key].new associated_attrs, @client
+        elsif defined?(self.class::TIME_FIELDS) && self.class::TIME_FIELDS.include?(key)
           value = Time.parse value
         end
         instance_variable_set "@#{key}", value

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -78,7 +78,6 @@ module Calendly
 
     def after_set_attributes(attrs)
       @uuid = self.class.extract_uuid(attrs[:uri]) if respond_to? :uuid=
-      true
     end
   end
 end

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -79,5 +79,24 @@ module Calendly
     def after_set_attributes(attrs)
       @uuid = self.class.extract_uuid(attrs[:uri]) if respond_to? :uuid=
     end
+
+    #
+    # Get all collection from single page or plurality of pages.
+    #
+    # @param [Proc] request_proc the procedure of request portion of collection.
+    # @param [Hash] opts the optional request parameters for the procedure.
+    # @return [Array<Calendly::Model>]
+    # @since 0.1.0
+    def auto_pagination(request_proc, opts)
+      items = []
+      loop do
+        event_types, next_opts = request_proc.call opts
+        items = [*items, *event_types]
+        break unless next_opts
+
+        opts = next_opts
+      end
+      items
+    end
   end
 end

--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -19,7 +19,7 @@ module Calendly
     # @raise [Calendly::Error] if the client is nil.
     # @since 0.1.0
     def client
-      raise Error, '@client is not ready.' unless @client
+      raise Error, '@client is not ready.' if !@client || !@client.is_a?(Client)
 
       @client
     end

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -12,5 +12,52 @@ module Calendly
     # @return [String]
     # Canonical resource reference.
     attr_accessor :uri
+
+    #
+    # Get List memberships of all users belonging to self.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :email Filter by email.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @return [Array<Calendly::OrganizationMembership>]
+    # @raise [Calendly::Error] if the uri is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def memberships(opts = {})
+      request_proc = proc { |options| client.memberships uri, options }
+      auto_pagination request_proc, opts
+    end
+
+    #
+    # Get Organization Invitations.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :email Filter by email.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Filter by status.
+    # @return [Array<Calendly::OrganizationInvitation>]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def invitations(opts = {})
+      request_proc = proc { |options| client.invitations uuid, options }
+      auto_pagination request_proc, opts
+    end
+
+    #
+    # Invite a person to an Organization.
+    #
+    # @param [String] email Email of the person being invited.
+    # @return [Calendly::OrganizationInvitation]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::Error] if the email is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def create_invitation(email)
+      client.create_invitation uuid, email
+    end
   end
 end

--- a/lib/calendly/models/organization_invitation.rb
+++ b/lib/calendly/models/organization_invitation.rb
@@ -43,6 +43,29 @@ module Calendly
     # If a person accepted the invitation, a reference to their User uuid.
     attr_accessor :user_uuid
 
+    #
+    # Get Organization Invitation associated with self.
+    #
+    # @return [Calendly::OrganizationInvitation]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def fetch
+      client.invitation organization_uuid, uuid
+    end
+
+    #
+    # Revoke self Invitation.
+    #
+    # @return [true]
+    # @raise [Calendly::Error] if the organization_uuid is empty.
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def delete
+      client.delete_invitation organization_uuid, uuid
+    end
+
     private
 
     def after_set_attributes(attrs)

--- a/lib/calendly/models/organization_invitation.rb
+++ b/lib/calendly/models/organization_invitation.rb
@@ -6,6 +6,7 @@ module Calendly
     include ModelUtils
     UUID_RE = %r{\A#{Client::API_HOST}/organizations/\w+/invitations/(\w+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at last_sent_at].freeze
+    ASSOCIATION = { user: User, organization: Organization }.freeze
 
     # @return [String]
     # unique id of the OrganizationInvitation object.
@@ -29,59 +30,38 @@ module Calendly
     # Moment when the last invitation was sent.
     attr_accessor :last_sent_at
 
-    # @return [String]
-    # Reference to Organization uri associated with this invitation.
-    attr_accessor :organization_uri
-    # @return [String]
-    # Reference to Organization uuid associated with this invitation.
-    attr_accessor :organization_uuid
+    # @return [Organization]
+    # Reference to Organization associated with this invitation.
+    attr_accessor :organization
 
-    # @return [String]
-    # If a person accepted the invitation, a reference to their User uri.
-    attr_accessor :user_uri
-    # @return [String]
-    # If a person accepted the invitation, a reference to their User uuid.
-    attr_accessor :user_uuid
+    # @return [User]
+    # If a person accepted the invitation, a reference to their User.
+    attr_accessor :user
 
     #
     # Get Organization Invitation associated with self.
     #
     # @return [Calendly::OrganizationInvitation]
+    # @raise [Calendly::Error] if the organization.uuid is empty.
     # @raise [Calendly::Error] if the uuid is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
     def fetch
-      client.invitation organization_uuid, uuid
+      org_uuid = organization.uuid if organization
+      client.invitation org_uuid, uuid
     end
 
     #
     # Revoke self Invitation.
     #
     # @return [true]
-    # @raise [Calendly::Error] if the organization_uuid is empty.
+    # @raise [Calendly::Error] if the organization.uuid is empty.
     # @raise [Calendly::Error] if the uuid is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
     def delete
-      client.delete_invitation organization_uuid, uuid
-    end
-
-    private
-
-    def after_set_attributes(attrs)
-      super attrs
-      if attrs[:user]
-        user_attrs = { uri: attrs[:user] }
-        user = User.new user_attrs, @client
-        @user_uri = user.uri
-        @user_uuid = user.uuid
-      end
-      if attrs[:organization]
-        org_attrs = { uri: attrs[:organization] }
-        org = Organization.new org_attrs, @client
-        @organization_uri = org.uri
-        @organization_uuid = org.uuid
-      end
+      org_uuid = organization.uuid if organization
+      client.delete_invitation org_uuid, uuid
     end
   end
 end

--- a/lib/calendly/models/organization_invitation.rb
+++ b/lib/calendly/models/organization_invitation.rb
@@ -48,18 +48,17 @@ module Calendly
     def after_set_attributes(attrs)
       super attrs
       if attrs[:user]
-        user_params = { uri: attrs[:user] }
-        user = User.new user_params
+        user_attrs = { uri: attrs[:user] }
+        user = User.new user_attrs, @client
         @user_uri = user.uri
         @user_uuid = user.uuid
       end
       if attrs[:organization]
-        org_params = { uri: attrs[:organization] }
-        org = Organization.new org_params
+        org_attrs = { uri: attrs[:organization] }
+        org = Organization.new org_attrs, @client
         @organization_uri = org.uri
         @organization_uuid = org.uuid
       end
-      true
     end
   end
 end

--- a/lib/calendly/models/organization_membership.rb
+++ b/lib/calendly/models/organization_membership.rb
@@ -34,6 +34,27 @@ module Calendly
     # Reference to Organization uuid associated with this membership.
     attr_accessor :organization_uuid
 
+    #
+    # Get Organization Membership associated with self.
+    #
+    # @return [Calendly::OrganizationMembership]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def fetch
+      client.membership uuid
+    end
+
+    #
+    # Remove self from associated Organization.
+    #
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def delete
+      client.delete_membership uuid
+    end
+
     private
 
     def after_set_attributes(attrs)

--- a/lib/calendly/models/organization_membership.rb
+++ b/lib/calendly/models/organization_membership.rb
@@ -6,6 +6,7 @@ module Calendly
     include ModelUtils
     UUID_RE = %r{\A#{Client::API_HOST}/organization_memberships/(\w+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
+    ASSOCIATION = { user: User, organization: Organization }.freeze
 
     # @return [String]
     # unique id of the OrganizationMembership object.
@@ -27,12 +28,9 @@ module Calendly
     # Primary account details of a specific user.
     attr_accessor :user
 
-    # @return [String]
-    # Reference to Organization uri associated with this membership.
-    attr_accessor :organization_uri
-    # @return [String]
-    # Reference to Organization uuid associated with this membership.
-    attr_accessor :organization_uuid
+    # @return [Organization]
+    # Reference to Organization associated with this membership.
+    attr_accessor :organization
 
     #
     # Get Organization Membership associated with self.
@@ -53,19 +51,6 @@ module Calendly
     # @since 0.1.0
     def delete
       client.delete_membership uuid
-    end
-
-    private
-
-    def after_set_attributes(attrs)
-      super attrs
-      @user = User.new attrs[:user], @client if attrs[:user]&.is_a? Hash
-      if attrs[:organization]
-        org_attrs = { uri: attrs[:organization] }
-        org = Organization.new org_attrs, @client
-        @organization_uri = org.uri
-        @organization_uuid = org.uuid
-      end
     end
   end
 end

--- a/lib/calendly/models/organization_membership.rb
+++ b/lib/calendly/models/organization_membership.rb
@@ -38,14 +38,13 @@ module Calendly
 
     def after_set_attributes(attrs)
       super attrs
-      @user = User.new attrs[:user] if attrs[:user]&.is_a?(Hash)
+      @user = User.new attrs[:user], @client if attrs[:user]&.is_a? Hash
       if attrs[:organization]
-        org_params = { uri: attrs[:organization] }
-        org = Organization.new org_params
+        org_attrs = { uri: attrs[:organization] }
+        org = Organization.new org_attrs, @client
         @organization_uri = org.uri
         @organization_uuid = org.uuid
       end
-      true
     end
   end
 end

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -56,7 +56,7 @@ module Calendly
     # @return [Calendly::OrganizationMembership]
     # @raise [Calendly::Error] if the uri is empty.
     # @since 0.1.0
-    def organization
+    def organization_membership
       mems, = client.memberships_by_user uri
       mems.first
     end

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -38,5 +38,77 @@ module Calendly
     # @return [Time]
     # Moment when user record was last updated.
     attr_accessor :updated_at
+
+    #
+    # Get basic information associated with self.
+    #
+    # @return [Calendly::User]
+    # @raise [Calendly::Error] if the uuid is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def fetch
+      client.user uuid
+    end
+
+    #
+    # Get an organization membership information associated with self.
+    #
+    # @return [Calendly::OrganizationMembership]
+    # @raise [Calendly::Error] if the uri is empty.
+    # @since 0.1.0
+    def organization
+      mems, = client.memberships_by_user uri
+      mems.first
+    end
+
+    #
+    # Returns all Event Types associated with self.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
+    # @return [Array<Calendly::EventType>]
+    # @raise [Calendly::Error] if the uri is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def event_types(opts = {})
+      request_proc = proc { |n_opts| client.event_types uri, n_opts }
+      auto_pagination request_proc, opts
+    end
+
+    #
+    # Returns all Scheduled Events associated with self.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email
+    # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Whether the scheduled event is active or canceled
+    # @return [Array<Calendly::Event>]
+    # @raise [Calendly::Error] if the user's uri is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.1.0
+    def scheduled_events(opts = {})
+      request_proc = proc { |n_opts| client.scheduled_events uri, n_opts }
+      auto_pagination request_proc, opts
+    end
+
+    private
+
+    def auto_pagination(request_proc, opts)
+      items = []
+      loop do
+        event_types, next_opts = request_proc.call opts
+        items = [*items, *event_types]
+        break unless next_opts
+
+        opts = next_opts
+      end
+      items
+    end
   end
 end

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -73,7 +73,7 @@ module Calendly
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
     def event_types(opts = {})
-      request_proc = proc { |n_opts| client.event_types uri, n_opts }
+      request_proc = proc { |options| client.event_types uri, options }
       auto_pagination request_proc, opts
     end
 
@@ -89,26 +89,12 @@ module Calendly
     # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # @option opts [String] :status Whether the scheduled event is active or canceled
     # @return [Array<Calendly::Event>]
-    # @raise [Calendly::Error] if the user's uri is empty.
+    # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
     def scheduled_events(opts = {})
-      request_proc = proc { |n_opts| client.scheduled_events uri, n_opts }
+      request_proc = proc { |options| client.scheduled_events uri, options }
       auto_pagination request_proc, opts
-    end
-
-    private
-
-    def auto_pagination(request_proc, opts)
-      items = []
-      loop do
-        event_types, next_opts = request_proc.call opts
-        items = [*items, *event_types]
-        break unless next_opts
-
-        opts = next_opts
-      end
-      items
     end
   end
 end

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Calendly
-  VERSION = '0.0.7.alpha'
+  VERSION = '0.1.0'
 end

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -4,6 +4,8 @@ require 'time'
 
 module AssertHelper
   def assert_user001(user)
+    assert user.client.is_a? Calendly::Client
+    assert_equal 'U001', user.id
     assert_equal 'U001', user.uuid
     assert_equal 'https://api.calendly.com/users/U001', user.uri
     assert_equal 'FooBar', user.name
@@ -17,6 +19,8 @@ module AssertHelper
   end
 
   def assert_user101(user)
+    assert user.client.is_a? Calendly::Client
+    assert_equal 'U101', user.id
     assert_equal 'U101', user.uuid
     assert_equal 'https://api.calendly.com/users/U101', user.uri
     assert_equal 'FooBar101', user.name
@@ -30,6 +34,8 @@ module AssertHelper
   end
 
   def assert_user102(user)
+    assert user.client.is_a? Calendly::Client
+    assert_equal 'U102', user.id
     assert_equal 'U102', user.uuid
     assert_equal 'https://api.calendly.com/users/U102', user.uri
     assert_equal 'FooBar102', user.name
@@ -43,6 +49,8 @@ module AssertHelper
   end
 
   def assert_user103(user)
+    assert user.client.is_a? Calendly::Client
+    assert_equal 'U103', user.id
     assert_equal 'U103', user.uuid
     assert_equal 'https://api.calendly.com/users/U103', user.uri
     assert_equal 'FooBar103', user.name
@@ -56,7 +64,9 @@ module AssertHelper
   end
 
   def assert_event_type001(ev_type)
+    assert ev_type.client.is_a? Calendly::Client
     assert_equal true, ev_type.active
+    assert_equal 'ET0001', ev_type.id
     assert_equal 'ET0001', ev_type.uuid
     assert_equal '#000001', ev_type.color
     assert_nil ev_type.description_html
@@ -79,7 +89,9 @@ module AssertHelper
   end
 
   def assert_event_type002(ev_type)
+    assert ev_type.client.is_a? Calendly::Client
     assert_equal false, ev_type.active
+    assert_equal 'ET0002', ev_type.id
     assert_equal 'ET0002', ev_type.uuid
     assert_equal '#000002', ev_type.color
     assert_nil ev_type.description_html
@@ -102,7 +114,9 @@ module AssertHelper
   end
 
   def assert_event_type003(ev_type)
+    assert ev_type.client.is_a? Calendly::Client
     assert_equal false, ev_type.active
+    assert_equal 'ET0003', ev_type.id
     assert_equal 'ET0003', ev_type.uuid
     assert_equal '#000003', ev_type.color
     assert_equal '<p>description</p>', ev_type.description_html
@@ -125,6 +139,8 @@ module AssertHelper
   end
 
   def assert_event001(ev)
+    assert ev.client.is_a? Calendly::Client
+    assert_equal 'EV001', ev.id
     assert_equal 'EV001', ev.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV001', ev.uri
     assert_equal '30 Minute Meeting', ev.name
@@ -142,6 +158,8 @@ module AssertHelper
   end
 
   def assert_event002(ev)
+    assert ev.client.is_a? Calendly::Client
+    assert_equal 'EV002', ev.id
     assert_equal 'EV002', ev.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV002', ev.uri
     assert_equal '15 Minute Meeting', ev.name
@@ -159,6 +177,8 @@ module AssertHelper
   end
 
   def assert_event003(ev)
+    assert ev.client.is_a? Calendly::Client
+    assert_equal 'EV003', ev.id
     assert_equal 'EV003', ev.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV003', ev.uri
     assert_equal '60 Minute Meeting', ev.name
@@ -176,6 +196,8 @@ module AssertHelper
   end
 
   def assert_event101_invitee001(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV001', inv.id
     assert_equal 'INV001', inv.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV101/invitees/INV001', inv.uri
     assert_equal 'foobar@example.com', inv.email
@@ -224,6 +246,8 @@ module AssertHelper
   end
 
   def assert_event201_invitee001(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV001', inv.id
     assert_equal 'INV001', inv.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV201/invitees/INV001', inv.uri
     assert_equal 'foobar@example.com', inv.email
@@ -257,6 +281,8 @@ module AssertHelper
   end
 
   def assert_event201_invitee002(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV002', inv.id
     assert_equal 'INV002', inv.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV201/invitees/INV002', inv.uri
     assert_equal 'foobar@example.com', inv.email
@@ -290,6 +316,8 @@ module AssertHelper
   end
 
   def assert_event201_invitee003(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV003', inv.id
     assert_equal 'INV003', inv.uuid
     assert_equal 'https://api.calendly.com/scheduled_events/EV201/invitees/INV003', inv.uri
     assert_equal 'foobar@example.com', inv.email
@@ -323,6 +351,8 @@ module AssertHelper
   end
 
   def assert_org_mem001(org_mem)
+    assert org_mem.client.is_a? Calendly::Client
+    assert_equal 'MEM001', org_mem.id
     assert_equal 'MEM001', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM001', org_mem.uri
     assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
@@ -334,6 +364,8 @@ module AssertHelper
   end
 
   def assert_org_mem002(org_mem)
+    assert org_mem.client.is_a? Calendly::Client
+    assert_equal 'MEM002', org_mem.id
     assert_equal 'MEM002', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM002', org_mem.uri
     assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
@@ -345,6 +377,8 @@ module AssertHelper
   end
 
   def assert_org_mem003(org_mem)
+    assert org_mem.client.is_a? Calendly::Client
+    assert_equal 'MEM003', org_mem.id
     assert_equal 'MEM003', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM003', org_mem.uri
     assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
@@ -356,6 +390,8 @@ module AssertHelper
   end
 
   def assert_org_inv001(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV001', inv.id
     assert_equal 'INV001', inv.uuid
     assert_equal 'https://api.calendly.com/organizations/ORG001/invitations/INV001', inv.uri
     assert_equal 'foobar102@example.com', inv.email
@@ -370,6 +406,8 @@ module AssertHelper
   end
 
   def assert_org_inv002(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV002', inv.id
     assert_equal 'INV002', inv.uuid
     assert_equal 'https://api.calendly.com/organizations/ORG001/invitations/INV002', inv.uri
     assert_equal 'foobar103@example.com', inv.email
@@ -384,6 +422,8 @@ module AssertHelper
   end
 
   def assert_org_inv003(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV003', inv.id
     assert_equal 'INV003', inv.uuid
     assert_equal 'https://api.calendly.com/organizations/ORG001/invitations/INV003', inv.uri
     assert_equal 'foobar104@example.com', inv.email

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -145,8 +145,8 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV001', ev.uri
     assert_equal '30 Minute Meeting', ev.name
     assert_equal 'canceled', ev.status
-    assert_equal 'https://api.calendly.com/event_types/ET001', ev.event_type_uri
-    assert_equal 'ET001', ev.event_type_uuid
+    assert_equal 'https://api.calendly.com/event_types/ET001', ev.event_type.uri
+    assert_equal 'ET001', ev.event_type.uuid
     assert_nil ev.location
     assert_equal 1, ev.invitees_counter_total
     assert_equal 0, ev.invitees_counter_active
@@ -164,8 +164,8 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV002', ev.uri
     assert_equal '15 Minute Meeting', ev.name
     assert_equal 'active', ev.status
-    assert_equal 'https://api.calendly.com/event_types/ET002', ev.event_type_uri
-    assert_equal 'ET002', ev.event_type_uuid
+    assert_equal 'https://api.calendly.com/event_types/ET002', ev.event_type.uri
+    assert_equal 'ET002', ev.event_type.uuid
     assert_equal 'Tokyo', ev.location
     assert_equal 1, ev.invitees_counter_total
     assert_equal 1, ev.invitees_counter_active
@@ -183,8 +183,8 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV003', ev.uri
     assert_equal '60 Minute Meeting', ev.name
     assert_equal 'active', ev.status
-    assert_equal 'https://api.calendly.com/event_types/ET003', ev.event_type_uri
-    assert_equal 'ET003', ev.event_type_uuid
+    assert_equal 'https://api.calendly.com/event_types/ET003', ev.event_type.uri
+    assert_equal 'ET003', ev.event_type.uuid
     assert_nil ev.location
     assert_equal 1, ev.invitees_counter_total
     assert_equal 1, ev.invitees_counter_active
@@ -204,8 +204,8 @@ module AssertHelper
     assert_equal 'FooBar', inv.name
     assert_equal 'active', inv.status
     assert_equal 'Asia/Tokyo', inv.timezone
-    assert_equal 'https://api.calendly.com/scheduled_events/EV101', inv.event_uri
-    assert_equal 'EV101', inv.event_uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV101', inv.event.uri
+    assert_equal 'EV101', inv.event.uuid
     assert_nil inv.text_reminder_number
     assert_equal Time.parse('2020-08-20T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-20T01:30:00.000000Z').to_i, inv.updated_at.to_i
@@ -254,8 +254,8 @@ module AssertHelper
     assert_equal 'FooBar', inv.name
     assert_equal 'active', inv.status
     assert_equal 'Asia/Tokyo', inv.timezone
-    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event_uri
-    assert_equal 'EV201', inv.event_uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
+    assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
     assert_equal Time.parse('2020-08-01T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-01T01:30:00.000000Z').to_i, inv.updated_at.to_i
@@ -289,8 +289,8 @@ module AssertHelper
     assert_equal 'FooBar', inv.name
     assert_equal 'active', inv.status
     assert_equal 'Asia/Tokyo', inv.timezone
-    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event_uri
-    assert_equal 'EV201', inv.event_uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
+    assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
     assert_equal Time.parse('2020-08-02T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-02T01:30:00.000000Z').to_i, inv.updated_at.to_i
@@ -324,8 +324,8 @@ module AssertHelper
     assert_equal 'FooBar', inv.name
     assert_equal 'active', inv.status
     assert_equal 'Asia/Tokyo', inv.timezone
-    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event_uri
-    assert_equal 'EV201', inv.event_uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
+    assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
     assert_equal Time.parse('2020-08-03T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-03T01:30:00.000000Z').to_i, inv.updated_at.to_i
@@ -355,8 +355,8 @@ module AssertHelper
     assert_equal 'MEM001', org_mem.id
     assert_equal 'MEM001', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM001', org_mem.uri
-    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
-    assert_equal 'ORG001', org_mem.organization_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization.uri
+    assert_equal 'ORG001', org_mem.organization.uuid
     assert_equal 'owner', org_mem.role
     assert_equal Time.parse('2020-07-01T00:00:00.000000Z').to_i, org_mem.created_at.to_i
     assert_equal Time.parse('2020-07-01T01:00:00.000000Z').to_i, org_mem.updated_at.to_i
@@ -368,8 +368,8 @@ module AssertHelper
     assert_equal 'MEM002', org_mem.id
     assert_equal 'MEM002', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM002', org_mem.uri
-    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
-    assert_equal 'ORG001', org_mem.organization_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization.uri
+    assert_equal 'ORG001', org_mem.organization.uuid
     assert_equal 'user', org_mem.role
     assert_equal Time.parse('2020-07-02T00:00:00.000000Z').to_i, org_mem.created_at.to_i
     assert_equal Time.parse('2020-07-02T01:00:00.000000Z').to_i, org_mem.updated_at.to_i
@@ -381,8 +381,8 @@ module AssertHelper
     assert_equal 'MEM003', org_mem.id
     assert_equal 'MEM003', org_mem.uuid
     assert_equal 'https://api.calendly.com/organization_memberships/MEM003', org_mem.uri
-    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization_uri
-    assert_equal 'ORG001', org_mem.organization_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', org_mem.organization.uri
+    assert_equal 'ORG001', org_mem.organization.uuid
     assert_equal 'user', org_mem.role
     assert_equal Time.parse('2020-07-03T00:00:00.000000Z').to_i, org_mem.created_at.to_i
     assert_equal Time.parse('2020-07-03T01:00:00.000000Z').to_i, org_mem.updated_at.to_i
@@ -399,10 +399,10 @@ module AssertHelper
     assert_equal Time.parse('2020-08-02T00:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-02T01:00:00.000000Z').to_i, inv.updated_at.to_i
     assert_equal Time.parse('2020-08-02T00:30:00.000000Z').to_i, inv.last_sent_at.to_i
-    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization_uri
-    assert_equal 'ORG001', inv.organization_uuid
-    assert_equal 'https://api.calendly.com/users/U102', inv.user_uri
-    assert_equal 'U102', inv.user_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization.uri
+    assert_equal 'ORG001', inv.organization.uuid
+    assert_equal 'https://api.calendly.com/users/U102', inv.user.uri
+    assert_equal 'U102', inv.user.uuid
   end
 
   def assert_org_inv002(inv)
@@ -415,10 +415,10 @@ module AssertHelper
     assert_equal Time.parse('2020-08-03T00:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-03T01:00:00.000000Z').to_i, inv.updated_at.to_i
     assert_equal Time.parse('2020-08-03T00:30:00.000000Z').to_i, inv.last_sent_at.to_i
-    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization_uri
-    assert_equal 'ORG001', inv.organization_uuid
-    assert_equal 'https://api.calendly.com/users/U103', inv.user_uri
-    assert_equal 'U103', inv.user_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization.uri
+    assert_equal 'ORG001', inv.organization.uuid
+    assert_equal 'https://api.calendly.com/users/U103', inv.user.uri
+    assert_equal 'U103', inv.user.uuid
   end
 
   def assert_org_inv003(inv)
@@ -431,10 +431,9 @@ module AssertHelper
     assert_equal Time.parse('2020-08-04T00:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-04T01:00:00.000000Z').to_i, inv.updated_at.to_i
     assert_equal Time.parse('2020-08-04T00:30:00.000000Z').to_i, inv.last_sent_at.to_i
-    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization_uri
-    assert_equal 'ORG001', inv.organization_uuid
-    assert_nil inv.user_uri
-    assert_nil inv.user_uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', inv.organization.uri
+    assert_equal 'ORG001', inv.organization.uuid
+    assert_nil inv.user
   end
 
   def assert_error(proc, ex_message)

--- a/test/calendly_client_test.rb
+++ b/test/calendly_client_test.rb
@@ -153,7 +153,7 @@ class CalendlyClientTest < CalendlyBaseTest
   end
 
   #
-  # test for event
+  # test for scheduled_event
   #
 
   def test_that_it_returns_a_specific_event
@@ -163,19 +163,19 @@ class CalendlyClientTest < CalendlyBaseTest
     url = "#{HOST}/scheduled_events/#{ev_uuid}"
     add_stub_request :get, url, res_body: res_body
 
-    ev = @client.event ev_uuid
+    ev = @client.scheduled_event ev_uuid
     assert_event001 ev
   end
 
   def test_that_it_returns_an_argument_error_on_event
     proc_arg_is_empty = proc do
-      @client.event ''
+      @client.scheduled_event ''
     end
     assert_required_error proc_arg_is_empty, 'uuid'
   end
 
   #
-  # test for events
+  # test for scheduled_events
   #
 
   def test_that_it_returns_all_items_of_event
@@ -186,7 +186,7 @@ class CalendlyClientTest < CalendlyBaseTest
     url = "#{HOST}/scheduled_events?#{URI.encode_www_form(params)}"
     add_stub_request :get, url, res_body: res_body
 
-    evs, next_params = @client.events user_uri
+    evs, next_params = @client.scheduled_events user_uri
     assert_equal 2, evs.length
     assert_nil next_params
     assert_event001 evs[0]
@@ -218,10 +218,10 @@ class CalendlyClientTest < CalendlyBaseTest
     add_stub_request :get, url2, res_body: res_body2
 
     # request page1
-    evs_page1, next_params1 = @client.events user_uri, params1
+    evs_page1, next_params1 = @client.scheduled_events user_uri, params1
     user_uri = next_params1.delete :user
     # request page2
-    evs_page2, next_params2 = @client.events user_uri, next_params1
+    evs_page2, next_params2 = @client.scheduled_events user_uri, next_params1
 
     assert_equal 2, evs_page1.length
     assert_equal 1, evs_page2.length
@@ -233,7 +233,7 @@ class CalendlyClientTest < CalendlyBaseTest
 
   def test_that_it_returns_an_argument_error_on_events
     proc_arg_is_empty = proc do
-      @client.events ''
+      @client.scheduled_events ''
     end
     assert_required_error proc_arg_is_empty, 'user_uri'
   end

--- a/test/calendly_client_test.rb
+++ b/test/calendly_client_test.rb
@@ -2,593 +2,613 @@
 
 require 'test_helper'
 
-class CalendlyClientTest < CalendlyBaseTest
-  def test_that_it_has_a_version_number
-    refute_nil ::Calendly::VERSION
-  end
+module Calendly
+  # test for Calendly::Client
+  class ClientTest < BaseTest
+    #
+    # test for initialize
+    #
 
-  #
-  # test for initialize
-  #
+    def test_that_it_returns_token_empty_error
+      proc_generate_client = proc do
+        Calendly::Client.new
+      end
+      assert_required_error proc_generate_client, 'token'
+    end
 
-  def test_that_it_returns_token_empty_error
-    proc_generate_client = proc do
+    def test_that_it_configure_client
+      init_configuration
+      config = Calendly.configuration
+      assert_equal @client_id, config.client_id
+      assert_equal @client_secret, config.client_secret
+      assert_equal @token, config.token
+      assert_equal @refresh_token, config.refresh_token
+      assert_equal @expires_at, config.token_expires_at
+      assert_equal @my_logger, config.logger
       Calendly::Client.new
     end
-    assert_required_error proc_generate_client, 'token'
-  end
 
-  def test_that_it_configure_client
-    init_configuration
-    config = Calendly.configuration
-    assert_equal @client_id, config.client_id
-    assert_equal @client_secret, config.client_secret
-    assert_equal @token, config.token
-    assert_equal @refresh_token, config.refresh_token
-    assert_equal @expires_at, config.token_expires_at
-    assert_equal @my_logger, config.logger
-    Calendly::Client.new
-  end
+    #
+    # refresh!
+    #
 
-  #
-  # refresh!
-  #
-
-  def test_that_it_returns_an_argument_error_on_refresh!
-    proc_client_id_is_empty = proc do
-      @client.refresh!
+    def test_that_it_returns_an_argument_error_on_refresh!
+      proc_client_id_is_empty = proc do
+        @client.refresh!
+      end
+      assert_required_error proc_client_id_is_empty, 'client_id'
     end
-    assert_required_error proc_client_id_is_empty, 'client_id'
-  end
 
-  def test_that_it_exchanges_new_access_token
-    init_configuration
-    add_refresh_token_stub_request
-    client = Calendly::Client.new
-    new_token = client.refresh!
-    assert_equal 'NEW_TOKEN', new_token.token
-    assert_equal 'NEW_REFRESH_TOKEN', new_token.refresh_token
-  end
-
-  def test_that_it_returns_an_invalid_token_error_on_initialize
-    is_expired = true
-    init_configuration(is_expired)
-    is_valid = false
-    add_refresh_token_stub_request(is_valid)
-    proc_invalid_grant = proc do
-      Calendly::Client.new
+    def test_that_it_exchanges_new_access_token
+      init_configuration
+      add_refresh_token_stub_request
+      client = Calendly::Client.new
+      new_token = client.refresh!
+      assert_equal 'NEW_TOKEN', new_token.token
+      assert_equal 'NEW_REFRESH_TOKEN', new_token.refresh_token
     end
-    assert_400_invalid_grant proc_invalid_grant
-  end
 
-  #
-  # test for current_user
-  #
-
-  def test_that_it_returns_a_current_user
-    res_body = load_test_data 'user_001.json'
-    add_stub_request :get, "#{HOST}/users/me", res_body: res_body
-
-    assert_user001 @client.current_user
-    assert_user001 @client.me
-  end
-
-  #
-  # test for user
-  #
-
-  def test_that_it_returns_a_specific_user
-    res_body = load_test_data 'user_001.json'
-    add_stub_request :get, "#{HOST}/users/U001", res_body: res_body
-
-    user = @client.user 'U001'
-    assert_user001 user
-  end
-
-  def test_that_it_returns_an_argument_error_on_user
-    proc_arg_is_nil = proc do
-      @client.user nil
+    def test_that_it_returns_an_invalid_token_error_on_initialize
+      is_expired = true
+      init_configuration(is_expired)
+      is_valid = false
+      add_refresh_token_stub_request(is_valid)
+      proc_invalid_grant = proc do
+        Calendly::Client.new
+      end
+      assert_400_invalid_grant proc_invalid_grant
     end
-    proc_arg_is_empty = proc do
-      @client.user ''
+
+    #
+    # test for current_user
+    #
+
+    def test_that_it_returns_a_current_user
+      res_body = load_test_data 'user_001.json'
+      add_stub_request :get, "#{HOST}/users/me", res_body: res_body
+
+      assert_user001 @client.current_user
+      assert_user001 @client.me
     end
-    assert_required_error proc_arg_is_nil, 'uuid'
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  #
-  # test for event_types
-  #
+    #
+    # test for user
+    #
 
-  def test_that_it_returns_all_items_of_event_type
-    user_uri = 'https://api.calendly.com/users/U001'
-    res_body = load_test_data 'event_types_001.json'
-    params = { user: user_uri }
+    def test_that_it_returns_a_specific_user
+      res_body = load_test_data 'user_001.json'
+      add_stub_request :get, "#{HOST}/users/U001", res_body: res_body
 
-    url = "#{HOST}/event_types?#{URI.encode_www_form(params)}"
-    add_stub_request :get, url, res_body: res_body
-
-    event_types, next_params = @client.event_types user_uri
-    assert_equal 3, event_types.length
-    assert_nil next_params
-    assert_event_type001 event_types[0]
-    assert_event_type002 event_types[1]
-    assert_event_type003 event_types[2]
-  end
-
-  def test_that_it_returns_all_items_of_event_type_by_pagination
-    user_uri = 'https://api.calendly.com/users/U001'
-
-    res_body1 = load_test_data 'event_types_002_page1.json'
-    option_params1 = { count: 2, sort: 'created_at:desc' }
-    params1 = { user: user_uri }.merge option_params1
-    url1 = "#{HOST}/event_types?#{URI.encode_www_form(params1)}"
-    add_stub_request :get, url1, res_body: res_body1
-
-    res_body2 = load_test_data 'event_types_002_page2.json'
-    option_params2 = { count: 2, page_token: 'NEXT_PAGE_TOKEN' }
-    params2 = { user: user_uri }.merge option_params2
-    url2 = "#{HOST}/event_types?#{URI.encode_www_form(params2)}"
-    add_stub_request :get, url2, res_body: res_body2
-
-    # request page1
-    event_types_page1, next_params1 = @client.event_types user_uri, option_params1
-    user_uri_page1 = next_params1.delete :user
-    # request page2
-    event_types_page2, next_params2 = @client.event_types user_uri_page1, next_params1
-
-    assert_equal 2, event_types_page1.length
-    assert_equal 1, event_types_page2.length
-    assert_nil next_params2
-    assert_event_type003 event_types_page1[0]
-    assert_event_type002 event_types_page1[1]
-    assert_event_type001 event_types_page2[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_event_types
-    proc_arg_is_empty = proc do
-      @client.event_types ''
+      user = @client.user 'U001'
+      assert_user001 user
     end
-    assert_required_error proc_arg_is_empty, 'user_uri'
-  end
 
-  #
-  # test for scheduled_event
-  #
-
-  def test_that_it_returns_a_specific_event
-    ev_uuid = 'EV001'
-    res_body = load_test_data 'scheduled_event_001.json'
-
-    url = "#{HOST}/scheduled_events/#{ev_uuid}"
-    add_stub_request :get, url, res_body: res_body
-
-    ev = @client.scheduled_event ev_uuid
-    assert_event001 ev
-  end
-
-  def test_that_it_returns_an_argument_error_on_event
-    proc_arg_is_empty = proc do
-      @client.scheduled_event ''
+    def test_that_it_returns_an_argument_error_on_user
+      proc_arg_is_nil = proc do
+        @client.user nil
+      end
+      proc_arg_is_empty = proc do
+        @client.user ''
+      end
+      assert_required_error proc_arg_is_nil, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid'
     end
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  #
-  # test for scheduled_events
-  #
+    #
+    # test for event_types
+    #
 
-  def test_that_it_returns_all_items_of_event
-    user_uri = 'https://api.calendly.com/users/U001'
-    res_body = load_test_data 'scheduled_events_001.json'
-    params = { user: user_uri }
+    def test_that_it_returns_all_items_of_event_type
+      user_uri = 'https://api.calendly.com/users/U001'
+      res_body = load_test_data 'event_types_001.json'
+      params = { user: user_uri }
 
-    url = "#{HOST}/scheduled_events?#{URI.encode_www_form(params)}"
-    add_stub_request :get, url, res_body: res_body
+      url = "#{HOST}/event_types?#{URI.encode_www_form(params)}"
+      add_stub_request :get, url, res_body: res_body
 
-    evs, next_params = @client.scheduled_events user_uri
-    assert_equal 2, evs.length
-    assert_nil next_params
-    assert_event001 evs[0]
-    assert_event002 evs[1]
-  end
-
-  def test_that_it_returns_all_items_of_event_by_pagination
-    user_uri = 'https://api.calendly.com/users/U001'
-    base_params = {
-      count: 2,
-      invitee_email: 'foobar@example.com',
-      max_start_time: '2020-08-01T00:00:00.000000Z',
-      min_start_time: '2020-07-01T00:00:00.000000Z',
-      user: user_uri,
-      status: 'active'
-    }
-    res_body1 = load_test_data 'scheduled_events_002_page1.json'
-    params1 = base_params.merge(
-      sort: 'start_time:desc'
-    )
-    url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
-    add_stub_request :get, url1, res_body: res_body1
-
-    res_body2 = load_test_data 'scheduled_events_002_page2.json'
-    params2 = base_params.merge(
-      page_token: 'NEXT_PAGE_TOKEN'
-    )
-    url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
-    add_stub_request :get, url2, res_body: res_body2
-
-    # request page1
-    evs_page1, next_params1 = @client.scheduled_events user_uri, params1
-    user_uri = next_params1.delete :user
-    # request page2
-    evs_page2, next_params2 = @client.scheduled_events user_uri, next_params1
-
-    assert_equal 2, evs_page1.length
-    assert_equal 1, evs_page2.length
-    assert_nil next_params2
-    assert_event003 evs_page1[0]
-    assert_event002 evs_page1[1]
-    assert_event001 evs_page2[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_events
-    proc_arg_is_empty = proc do
-      @client.scheduled_events ''
+      event_types, next_params = @client.event_types user_uri
+      assert_equal 3, event_types.length
+      assert_nil next_params
+      assert_event_type001 event_types[0]
+      assert_event_type002 event_types[1]
+      assert_event_type003 event_types[2]
     end
-    assert_required_error proc_arg_is_empty, 'user_uri'
-  end
 
-  #
-  # test for event_invitee
-  #
+    def test_that_it_returns_all_items_of_event_type_by_pagination
+      user_uri = 'https://api.calendly.com/users/U001'
 
-  def test_that_it_returns_a_one_on_one_event_invitee
-    ev_uuid = 'EV101'
-    inv_uuid = 'INV001'
-    res_body = load_test_data 'scheduled_event_invitee_101.json'
+      res_body1 = load_test_data 'event_types_002_page1.json'
+      option_params1 = { count: 2, sort: 'created_at:desc' }
+      params1 = { user: user_uri }.merge option_params1
+      url1 = "#{HOST}/event_types?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
 
-    url = "#{HOST}/scheduled_events/#{ev_uuid}/invitees/#{inv_uuid}"
-    add_stub_request :get, url, res_body: res_body
+      res_body2 = load_test_data 'event_types_002_page2.json'
+      option_params2 = { count: 2, page_token: 'NEXT_PAGE_TOKEN' }
+      params2 = { user: user_uri }.merge option_params2
+      url2 = "#{HOST}/event_types?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
 
-    inv = @client.event_invitee ev_uuid, inv_uuid
-    assert_event101_invitee001 inv
-  end
+      # request page1
+      event_types_page1, next_params1 = @client.event_types user_uri, option_params1
+      user_uri_page1 = next_params1.delete :user
+      # request page2
+      event_types_page2, next_params2 = @client.event_types user_uri_page1, next_params1
 
-  def test_that_it_returns_an_argument_error_on_event_invitee
-    proc_ev_uuid_arg_is_empty = proc do
-      @client.event_invitee '', 'INV001'
+      assert_equal 2, event_types_page1.length
+      assert_equal 1, event_types_page2.length
+      assert_nil next_params2
+      assert_event_type003 event_types_page1[0]
+      assert_event_type002 event_types_page1[1]
+      assert_event_type001 event_types_page2[0]
     end
-    proc_inv_uuid_arg_is_empty = proc do
-      @client.event_invitee 'EV001', ''
+
+    def test_that_it_returns_an_argument_error_on_event_types
+      proc_arg_is_empty = proc do
+        @client.event_types ''
+      end
+      assert_required_error proc_arg_is_empty, 'user_uri'
     end
-    assert_required_error proc_ev_uuid_arg_is_empty, 'ev_uuid'
-    assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
-  end
 
-  #
-  # test for event_invitees
-  #
+    #
+    # test for scheduled_event
+    #
 
-  def test_that_it_returns_one_on_one_event_invitees
-    ev_uuid = 'EV001'
-    res_body = load_test_data 'scheduled_event_invitees_101.json'
+    def test_that_it_returns_a_specific_event
+      ev_uuid = 'EV001'
+      res_body = load_test_data 'scheduled_event_001.json'
 
-    url = "#{HOST}/scheduled_events/#{ev_uuid}/invitees"
-    add_stub_request :get, url, res_body: res_body
+      url = "#{HOST}/scheduled_events/#{ev_uuid}"
+      add_stub_request :get, url, res_body: res_body
 
-    invs, next_params = @client.event_invitees ev_uuid
-    assert_equal 1, invs.length
-    assert_nil next_params
-    assert_event101_invitee001 invs[0]
-  end
-
-  def test_that_it_returns_group_event_invitees
-    ev_uuid = 'EV201'
-    base_params = {
-      count: 2,
-      email: 'foobar@example.com',
-      status: 'active'
-    }
-
-    res_body1 = load_test_data 'scheduled_event_invitees_201_page1.json'
-    params1 = base_params.merge(
-      sort: 'created_at:desc'
-    )
-    url1 = "#{HOST}/scheduled_events/#{ev_uuid}/invitees?#{URI.encode_www_form(params1)}"
-    add_stub_request :get, url1, res_body: res_body1
-
-    res_body2 = load_test_data 'scheduled_event_invitees_201_page2.json'
-    params2 = base_params.merge(
-      page_token: 'NEXT_PAGE_TOKEN'
-    )
-    url2 = "#{HOST}/scheduled_events/#{ev_uuid}/invitees?#{URI.encode_www_form(params2)}"
-    add_stub_request :get, url2, res_body: res_body2
-
-    # request page1
-    invs_page1, next_params1 = @client.event_invitees ev_uuid, params1
-    # request page2
-    invs_page2, next_params2 = @client.event_invitees ev_uuid, next_params1
-
-    assert_equal 2, invs_page1.length
-    assert_equal 1, invs_page2.length
-    assert_nil next_params2
-    assert_event201_invitee003 invs_page1[0]
-    assert_event201_invitee002 invs_page1[1]
-    assert_event201_invitee001 invs_page2[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_event_invitees
-    proc_arg_is_empty = proc do
-      @client.event_invitees ''
+      ev = @client.scheduled_event ev_uuid
+      assert_event001 ev
     end
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  #
-  # test for membership
-  #
-
-  def test_that_it_returns_a_specific_membership
-    org_uuid = 'ORG001'
-    res_body = load_test_data 'organization_membership_001.json'
-    url = "#{HOST}/organization_memberships/#{org_uuid}"
-    add_stub_request :get, url, res_body: res_body
-
-    mem = @client.membership org_uuid
-    assert_org_mem001 mem
-  end
-
-  def test_that_it_returns_an_argument_error_on_membership
-    proc_arg_is_empty = proc do
-      @client.membership ''
+    def test_that_it_returns_an_argument_error_on_event
+      proc_arg_is_empty = proc do
+        @client.scheduled_event ''
+      end
+      assert_required_error proc_arg_is_empty, 'uuid'
     end
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  #
-  # test for memberships
-  #
+    #
+    # test for scheduled_events
+    #
 
-  def test_that_it_returns_all_memberships_by_pagination
-    org_uri = 'https://api.calendly.com/organizations/ORG001'
-    base_params = {
-      organization: org_uri,
-      count: 2
-    }
+    def test_that_it_returns_all_items_of_event
+      user_uri = 'https://api.calendly.com/users/U001'
+      res_body = load_test_data 'scheduled_events_001.json'
+      params = { user: user_uri }
 
-    params1 = base_params.dup
-    res_body1 = load_test_data 'organization_memberships_002_page1.json'
-    url1 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params1)}"
-    add_stub_request :get, url1, res_body: res_body1
+      url = "#{HOST}/scheduled_events?#{URI.encode_www_form(params)}"
+      add_stub_request :get, url, res_body: res_body
 
-    res_body2 = load_test_data 'organization_memberships_002_page2.json'
-    params2 = base_params.merge(
-      page_token: 'NEXT_PAGE_TOKEN'
-    )
-    url2 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params2)}"
-    add_stub_request :get, url2, res_body: res_body2
-
-    # request page1
-    mems_page1, next_params1 = @client.memberships org_uri, params1
-    org_uri = next_params1.delete(:organization)
-    # request page2
-    mems_page2, next_params2 = @client.memberships org_uri, next_params1
-
-    assert_equal 2, mems_page1.length
-    assert_equal 1, mems_page2.length
-    assert_nil next_params2
-    assert_org_mem001 mems_page1[0]
-    assert_org_mem002 mems_page1[1]
-    assert_org_mem003 mems_page2[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_memberships
-    proc_arg_is_empty = proc do
-      @client.memberships ''
+      evs, next_params = @client.scheduled_events user_uri
+      assert_equal 2, evs.length
+      assert_nil next_params
+      assert_event001 evs[0]
+      assert_event002 evs[1]
     end
-    assert_required_error proc_arg_is_empty, 'org_uri'
-  end
 
-  #
-  # test for memberships_by_user
-  #
+    def test_that_it_returns_all_items_of_event_by_pagination
+      user_uri = 'https://api.calendly.com/users/U001'
+      base_params = {
+        count: 2,
+        invitee_email: 'foobar@example.com',
+        max_start_time: '2020-08-01T00:00:00.000000Z',
+        min_start_time: '2020-07-01T00:00:00.000000Z',
+        user: user_uri,
+        status: 'active'
+      }
+      res_body1 = load_test_data 'scheduled_events_002_page1.json'
+      params1 = base_params.merge(
+        sort: 'start_time:desc'
+      )
+      url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
 
-  def test_that_it_returns_memberships_specific_user
-    user_uri = 'https://api.calendly.com/users/U101'
-    res_body = load_test_data 'organization_memberships_001.json'
+      res_body2 = load_test_data 'scheduled_events_002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
 
-    params = { user: user_uri }
-    url = "#{HOST}/organization_memberships?#{URI.encode_www_form(params)}"
-    add_stub_request :get, url, res_body: res_body
+      # request page1
+      evs_page1, next_params1 = @client.scheduled_events user_uri, params1
+      user_uri = next_params1.delete :user
+      # request page2
+      evs_page2, next_params2 = @client.scheduled_events user_uri, next_params1
 
-    mems, next_params = @client.memberships_by_user user_uri
-    assert_equal 1, mems.length
-    assert_nil next_params
-    assert_org_mem001 mems[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_memberships_by_user
-    proc_arg_is_empty = proc do
-      @client.memberships_by_user ''
+      assert_equal 2, evs_page1.length
+      assert_equal 1, evs_page2.length
+      assert_nil next_params2
+      assert_event003 evs_page1[0]
+      assert_event002 evs_page1[1]
+      assert_event001 evs_page2[0]
     end
-    assert_required_error proc_arg_is_empty, 'user_uri'
-  end
 
-  #
-  # test for delete_membership
-  #
-
-  def test_that_it_deletes_an_exists_membership
-    uuid = 'MEM001'
-    url = "#{HOST}/organization_memberships/#{uuid}"
-    add_stub_request :delete, url, res_status: 204
-
-    result = @client.delete_membership uuid
-    assert_equal true, result
-  end
-
-  def test_that_it_returns_an_argument_error_on_delete_membership
-    proc_arg_is_empty = proc do
-      @client.delete_membership ''
+    def test_that_it_returns_an_argument_error_on_events
+      proc_arg_is_empty = proc do
+        @client.scheduled_events ''
+      end
+      assert_required_error proc_arg_is_empty, 'user_uri'
     end
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  def test_that_it_returns_an_error_not_found_on_delete_membership
-    uuid = 'MEM001'
-    res_body = load_test_data 'error_404_not_found.json'
-    url = "#{HOST}/organization_memberships/#{uuid}"
-    add_stub_request :delete, url, res_body: res_body, res_status: 404
+    #
+    # test for event_invitee
+    #
 
-    proc_404 = proc do
-      @client.delete_membership uuid
+    def test_that_it_returns_a_one_on_one_event_invitee
+      ev_uuid = 'EV101'
+      inv_uuid = 'INV001'
+      res_body = load_test_data 'scheduled_event_invitee_101.json'
+
+      url = "#{HOST}/scheduled_events/#{ev_uuid}/invitees/#{inv_uuid}"
+      add_stub_request :get, url, res_body: res_body
+
+      inv = @client.event_invitee ev_uuid, inv_uuid
+      assert_event101_invitee001 inv
     end
-    assert_404_error proc_404
-  end
 
-  #
-  # test for invitation
-  #
-
-  def test_that_it_returns_a_specific_invitation
-    org_uuid = 'ORG001'
-    inv_uuid = 'INV001'
-    res_body = load_test_data 'organization_invitation_001.json'
-    url = "#{HOST}/organizations/#{org_uuid}/invitations/#{inv_uuid}"
-    add_stub_request :get, url, res_body: res_body
-
-    inv = @client.invitation org_uuid, inv_uuid
-    assert_org_inv001 inv
-  end
-
-  def test_that_it_returns_an_argument_error_on_invitation
-    proc_org_uuid_arg_is_empty = proc do
-      @client.invitation '', 'INV001'
+    def test_that_it_returns_an_argument_error_on_event_invitee
+      proc_ev_uuid_arg_is_empty = proc do
+        @client.event_invitee '', 'INV001'
+      end
+      proc_inv_uuid_arg_is_empty = proc do
+        @client.event_invitee 'EV001', ''
+      end
+      assert_required_error proc_ev_uuid_arg_is_empty, 'ev_uuid'
+      assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
     end
-    proc_inv_uuid_arg_is_empty = proc do
-      @client.invitation 'ORG001', ''
+
+    #
+    # test for event_invitees
+    #
+
+    def test_that_it_returns_one_on_one_event_invitees
+      ev_uuid = 'EV001'
+      res_body = load_test_data 'scheduled_event_invitees_101.json'
+
+      url = "#{HOST}/scheduled_events/#{ev_uuid}/invitees"
+      add_stub_request :get, url, res_body: res_body
+
+      invs, next_params = @client.event_invitees ev_uuid
+      assert_equal 1, invs.length
+      assert_nil next_params
+      assert_event101_invitee001 invs[0]
     end
-    assert_required_error proc_org_uuid_arg_is_empty, 'org_uuid'
-    assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
-  end
 
-  #
-  # test for invitations
-  #
+    def test_that_it_returns_group_event_invitees
+      ev_uuid = 'EV201'
+      base_params = {
+        count: 2,
+        email: 'foobar@example.com',
+        status: 'active'
+      }
 
-  def test_that_it_returns_all_organization_invitations
-    org_uuid = 'ORG001'
-    res_body = load_test_data 'organization_invitations_001.json'
-    url = "#{HOST}/organizations/#{org_uuid}/invitations"
-    add_stub_request :get, url, res_body: res_body
+      res_body1 = load_test_data 'scheduled_event_invitees_201_page1.json'
+      params1 = base_params.merge(
+        sort: 'created_at:desc'
+      )
+      url1 = "#{HOST}/scheduled_events/#{ev_uuid}/invitees?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
 
-    invs, next_params = @client.invitations org_uuid
-    assert_equal 3, invs.length
-    assert_nil next_params
-    assert_org_inv001 invs[0]
-    assert_org_inv002 invs[1]
-    assert_org_inv003 invs[2]
-  end
+      res_body2 = load_test_data 'scheduled_event_invitees_201_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events/#{ev_uuid}/invitees?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
 
-  def test_that_it_returns_all_organization_invitations_by_pagination
-    org_uuid = 'ORG001'
-    base_params = { count: 2 }
+      # request page1
+      invs_page1, next_params1 = @client.event_invitees ev_uuid, params1
+      # request page2
+      invs_page2, next_params2 = @client.event_invitees ev_uuid, next_params1
 
-    params1 = base_params.merge(sort: 'created_at:desc')
-    res_body1 = load_test_data 'organization_invitations_002_page1.json'
-    url1 = "#{HOST}/organizations/#{org_uuid}/invitations?#{URI.encode_www_form(params1)}"
-    add_stub_request :get, url1, res_body: res_body1
-
-    res_body2 = load_test_data 'organization_invitations_002_page2.json'
-    params2 = base_params.merge(
-      page_token: 'NEXT_PAGE_TOKEN'
-    )
-    url2 = "#{HOST}/organizations/#{org_uuid}/invitations?#{URI.encode_www_form(params2)}"
-    add_stub_request :get, url2, res_body: res_body2
-
-    # request page1
-    invs_page1, next_params1 = @client.invitations org_uuid, params1
-    # request page2
-    invs_page2, next_params2 = @client.invitations org_uuid, next_params1
-
-    assert_equal 2, invs_page1.length
-    assert_equal 1, invs_page2.length
-    assert_nil next_params2
-    assert_org_inv003 invs_page1[0]
-    assert_org_inv002 invs_page1[1]
-    assert_org_inv001 invs_page2[0]
-  end
-
-  def test_that_it_returns_an_argument_error_on_invitations
-    proc_arg_is_empty = proc do
-      @client.invitations ''
+      assert_equal 2, invs_page1.length
+      assert_equal 1, invs_page2.length
+      assert_nil next_params2
+      assert_event201_invitee003 invs_page1[0]
+      assert_event201_invitee002 invs_page1[1]
+      assert_event201_invitee001 invs_page2[0]
     end
-    assert_required_error proc_arg_is_empty, 'uuid'
-  end
 
-  #
-  # test for create_invitation
-  #
-
-  def test_that_it_creates_invitation
-    org_uuid = 'ORG001'
-    email = 'foobar@example.com'
-    req_body = { email: email }
-    res_body = load_test_data 'organization_invitation_003_create.json'
-    url = "#{HOST}/organizations/#{org_uuid}/invitations"
-    add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
-
-    inv = @client.create_invitation org_uuid, email
-    assert_org_inv003 inv
-  end
-
-  def test_that_it_returns_an_argument_error_on_create_invitation
-    proc_uuid_arg_is_empty = proc do
-      @client.create_invitation '', 'foobar@example.com'
+    def test_that_it_returns_an_argument_error_on_event_invitees
+      proc_arg_is_empty = proc do
+        @client.event_invitees ''
+      end
+      assert_required_error proc_arg_is_empty, 'uuid'
     end
-    proc_email_arg_is_empty = proc do
-      @client.create_invitation 'ORG001', ''
+
+    #
+    # test for membership
+    #
+
+    def test_that_it_returns_a_specific_membership
+      org_uuid = 'ORG001'
+      res_body = load_test_data 'organization_membership_001.json'
+      url = "#{HOST}/organization_memberships/#{org_uuid}"
+      add_stub_request :get, url, res_body: res_body
+
+      mem = @client.membership org_uuid
+      assert_org_mem001 mem
     end
-    assert_required_error proc_uuid_arg_is_empty, 'uuid'
-    assert_required_error proc_email_arg_is_empty, 'email'
-  end
 
-  def test_that_it_returns_an_error_already_invited
-    org_uuid = 'ORG001'
-    email = 'foobar@example.com'
-    req_body = { email: email }
-    res_body = load_test_data 'error_400_already_invited.json'
-    url = "#{HOST}/organizations/#{org_uuid}/invitations"
-    add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 400
-
-    proc_400_error = proc do
-      @client.create_invitation org_uuid, email
+    def test_that_it_returns_an_argument_error_on_membership
+      proc_arg_is_empty = proc do
+        @client.membership ''
+      end
+      assert_required_error proc_arg_is_empty, 'uuid'
     end
-    assert_400_already_invited proc_400_error, email
-  end
 
-  #
-  # test for delete_invitation
-  #
+    #
+    # test for memberships
+    #
 
-  def test_that_it_deletes_invitation
-    org_uuid = 'ORG001'
-    inv_uuid = 'INV001'
-    url = "#{HOST}/organizations/#{org_uuid}/invitations/#{inv_uuid}"
-    add_stub_request :delete, url, res_status: 204
+    def test_that_it_returns_all_memberships_by_pagination
+      org_uri = 'https://api.calendly.com/organizations/ORG001'
+      base_params = {
+        organization: org_uri,
+        count: 2
+      }
 
-    result = @client.delete_invitation org_uuid, inv_uuid
-    assert_equal true, result
-  end
+      params1 = base_params.dup
+      res_body1 = load_test_data 'organization_memberships_002_page1.json'
+      url1 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
 
-  def test_that_it_returns_an_argument_error_on_delete_invitation
-    proc_org_uuid_arg_is_empty = proc do
-      @client.delete_invitation '', 'INV001'
+      res_body2 = load_test_data 'organization_memberships_002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      # request page1
+      mems_page1, next_params1 = @client.memberships org_uri, params1
+      org_uri = next_params1.delete(:organization)
+      # request page2
+      mems_page2, next_params2 = @client.memberships org_uri, next_params1
+
+      assert_equal 2, mems_page1.length
+      assert_equal 1, mems_page2.length
+      assert_nil next_params2
+      assert_org_mem001 mems_page1[0]
+      assert_org_mem002 mems_page1[1]
+      assert_org_mem003 mems_page2[0]
     end
-    proc_inv_uuid_arg_is_empty = proc do
-      @client.delete_invitation 'ORG001', ''
+
+    def test_that_it_returns_an_argument_error_on_memberships
+      proc_arg_is_empty = proc do
+        @client.memberships ''
+      end
+      assert_required_error proc_arg_is_empty, 'org_uri'
     end
-    assert_required_error proc_org_uuid_arg_is_empty, 'org_uuid'
-    assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
+
+    #
+    # test for memberships_by_user
+    #
+
+    def test_that_it_returns_memberships_specific_user
+      user_uri = 'https://api.calendly.com/users/U101'
+      res_body = load_test_data 'organization_memberships_001.json'
+
+      params = { user: user_uri }
+      url = "#{HOST}/organization_memberships?#{URI.encode_www_form(params)}"
+      add_stub_request :get, url, res_body: res_body
+
+      mems, next_params = @client.memberships_by_user user_uri
+      assert_equal 1, mems.length
+      assert_nil next_params
+      assert_org_mem001 mems[0]
+    end
+
+    def test_that_it_returns_an_argument_error_on_memberships_by_user
+      proc_arg_is_empty = proc do
+        @client.memberships_by_user ''
+      end
+      assert_required_error proc_arg_is_empty, 'user_uri'
+    end
+
+    #
+    # test for delete_membership
+    #
+
+    def test_that_it_deletes_an_exists_membership
+      uuid = 'MEM001'
+      url = "#{HOST}/organization_memberships/#{uuid}"
+      add_stub_request :delete, url, res_status: 204
+
+      result = @client.delete_membership uuid
+      assert_equal true, result
+    end
+
+    def test_that_it_returns_an_argument_error_on_delete_membership
+      proc_arg_is_empty = proc do
+        @client.delete_membership ''
+      end
+      assert_required_error proc_arg_is_empty, 'uuid'
+    end
+
+    def test_that_it_returns_an_error_not_found_on_delete_membership
+      uuid = 'MEM001'
+      res_body = load_test_data 'error_404_not_found.json'
+      url = "#{HOST}/organization_memberships/#{uuid}"
+      add_stub_request :delete, url, res_body: res_body, res_status: 404
+
+      proc_404 = proc do
+        @client.delete_membership uuid
+      end
+      assert_404_error proc_404
+    end
+
+    #
+    # test for invitation
+    #
+
+    def test_that_it_returns_a_specific_invitation
+      org_uuid = 'ORG001'
+      inv_uuid = 'INV001'
+      res_body = load_test_data 'organization_invitation_001.json'
+      url = "#{HOST}/organizations/#{org_uuid}/invitations/#{inv_uuid}"
+      add_stub_request :get, url, res_body: res_body
+
+      inv = @client.invitation org_uuid, inv_uuid
+      assert_org_inv001 inv
+    end
+
+    def test_that_it_returns_an_argument_error_on_invitation
+      proc_org_uuid_arg_is_empty = proc do
+        @client.invitation '', 'INV001'
+      end
+      proc_inv_uuid_arg_is_empty = proc do
+        @client.invitation 'ORG001', ''
+      end
+      assert_required_error proc_org_uuid_arg_is_empty, 'org_uuid'
+      assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
+    end
+
+    #
+    # test for invitations
+    #
+
+    def test_that_it_returns_all_organization_invitations
+      org_uuid = 'ORG001'
+      res_body = load_test_data 'organization_invitations_001.json'
+      url = "#{HOST}/organizations/#{org_uuid}/invitations"
+      add_stub_request :get, url, res_body: res_body
+
+      invs, next_params = @client.invitations org_uuid
+      assert_equal 3, invs.length
+      assert_nil next_params
+      assert_org_inv001 invs[0]
+      assert_org_inv002 invs[1]
+      assert_org_inv003 invs[2]
+    end
+
+    def test_that_it_returns_all_organization_invitations_by_pagination
+      org_uuid = 'ORG001'
+      base_params = { count: 2 }
+
+      params1 = base_params.merge(sort: 'created_at:desc')
+      res_body1 = load_test_data 'organization_invitations_002_page1.json'
+      url1 = "#{HOST}/organizations/#{org_uuid}/invitations?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      res_body2 = load_test_data 'organization_invitations_002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/organizations/#{org_uuid}/invitations?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      # request page1
+      invs_page1, next_params1 = @client.invitations org_uuid, params1
+      # request page2
+      invs_page2, next_params2 = @client.invitations org_uuid, next_params1
+
+      assert_equal 2, invs_page1.length
+      assert_equal 1, invs_page2.length
+      assert_nil next_params2
+      assert_org_inv003 invs_page1[0]
+      assert_org_inv002 invs_page1[1]
+      assert_org_inv001 invs_page2[0]
+    end
+
+    def test_that_it_returns_an_argument_error_on_invitations
+      proc_arg_is_empty = proc do
+        @client.invitations ''
+      end
+      assert_required_error proc_arg_is_empty, 'uuid'
+    end
+
+    #
+    # test for create_invitation
+    #
+
+    def test_that_it_creates_invitation
+      org_uuid = 'ORG001'
+      email = 'foobar@example.com'
+      req_body = { email: email }
+      res_body = load_test_data 'organization_invitation_003_create.json'
+      url = "#{HOST}/organizations/#{org_uuid}/invitations"
+      add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
+
+      inv = @client.create_invitation org_uuid, email
+      assert_org_inv003 inv
+    end
+
+    def test_that_it_returns_an_argument_error_on_create_invitation
+      proc_uuid_arg_is_empty = proc do
+        @client.create_invitation '', 'foobar@example.com'
+      end
+      proc_email_arg_is_empty = proc do
+        @client.create_invitation 'ORG001', ''
+      end
+      assert_required_error proc_uuid_arg_is_empty, 'uuid'
+      assert_required_error proc_email_arg_is_empty, 'email'
+    end
+
+    def test_that_it_returns_an_error_already_invited
+      org_uuid = 'ORG001'
+      email = 'foobar@example.com'
+      req_body = { email: email }
+      res_body = load_test_data 'error_400_already_invited.json'
+      url = "#{HOST}/organizations/#{org_uuid}/invitations"
+      add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 400
+
+      proc_400_error = proc do
+        @client.create_invitation org_uuid, email
+      end
+      assert_400_already_invited proc_400_error, email
+    end
+
+    #
+    # test for delete_invitation
+    #
+
+    def test_that_it_deletes_invitation
+      org_uuid = 'ORG001'
+      inv_uuid = 'INV001'
+      url = "#{HOST}/organizations/#{org_uuid}/invitations/#{inv_uuid}"
+      add_stub_request :delete, url, res_status: 204
+
+      result = @client.delete_invitation org_uuid, inv_uuid
+      assert_equal true, result
+    end
+
+    def test_that_it_returns_an_argument_error_on_delete_invitation
+      proc_org_uuid_arg_is_empty = proc do
+        @client.delete_invitation '', 'INV001'
+      end
+      proc_inv_uuid_arg_is_empty = proc do
+        @client.delete_invitation 'ORG001', ''
+      end
+      assert_required_error proc_org_uuid_arg_is_empty, 'org_uuid'
+      assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
+    end
+
+    private
+
+    def add_refresh_token_stub_request(is_valid = true)
+      req_params = {
+        client_id: @client_id,
+        client_secret: @client_secret,
+        grant_type: 'refresh_token',
+        refresh_token: @refresh_token
+      }
+      req_body = URI.encode_www_form(req_params)
+      if is_valid
+        res_status = 200
+        res_body = load_test_data 'refresh_token.json'
+      else
+        res_status = 400
+        res_body = load_test_data 'error_400_invalid_grant.json'
+      end
+      url = "#{Calendly::Client::AUTH_API_HOST}/oauth/token"
+      stub_request(:post, url).with(body: req_body).to_return(status: res_status, body: res_body, headers: default_response_headers)
+    end
   end
 end

--- a/test/calendly_client_test.rb
+++ b/test/calendly_client_test.rb
@@ -327,12 +327,12 @@ module Calendly
     #
 
     def test_that_it_returns_a_specific_membership
-      org_uuid = 'ORG001'
+      mem_uuid = 'MEM001'
       res_body = load_test_data 'organization_membership_001.json'
-      url = "#{HOST}/organization_memberships/#{org_uuid}"
+      url = "#{HOST}/organization_memberships/#{mem_uuid}"
       add_stub_request :get, url, res_body: res_body
 
-      mem = @client.membership org_uuid
+      mem = @client.membership mem_uuid
       assert_org_mem001 mem
     end
 

--- a/test/models/event_invitee_test.rb
+++ b/test/models/event_invitee_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::Invitee
+  class InviteeTest < BaseTest
+    def setup
+      super
+      ev_uuid = 'EV101'
+      event_uri = "#{HOST}/scheduled_events/#{ev_uuid}"
+
+      @inv_uuid = 'INV001'
+      @inv_uri = "#{event_uri}/invitees/#{@inv_uuid}"
+      attrs = { uri: @inv_uri, event: event_uri }
+      @invitee = Invitee.new attrs, @client
+      @invitee_no_client = Invitee.new attrs
+    end
+
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @invitee_no_client.fetch
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
+    def test_that_it_returns_an_associated_invitee
+      res_body = load_test_data 'scheduled_event_invitee_101.json'
+      add_stub_request :get, @inv_uri, res_body: res_body
+      assert_event101_invitee001 @invitee.fetch
+    end
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -29,7 +29,7 @@ module Calendly
 
     def test_that_it_returns_event_invitees_in_single_page
       res_body = load_test_data 'scheduled_event_invitees_101.json'
-      url = "#{HOST}/scheduled_events/#{@ev_uuid}/invitees"
+      url = "#{@ev_uri}/invitees"
       add_stub_request :get, url, res_body: res_body
 
       invs = @event.invitees

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::Event
+  class EventTest < BaseTest
+    def setup
+      super
+      @ev_uuid = 'EV001'
+      @ev_uri = "#{HOST}/scheduled_events/#{@ev_uuid}"
+      attrs = { uri: @ev_uri }
+      @event = Event.new attrs, @client
+      @event_no_client = Event.new attrs
+    end
+
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @event_no_client.fetch
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
+    def test_that_it_returns_an_associated_event
+      res_body = load_test_data 'scheduled_event_001.json'
+      add_stub_request :get, @ev_uri, res_body: res_body
+      assert_event001 @event.fetch
+    end
+
+    def test_that_it_returns_event_invitees_in_single_page
+      res_body = load_test_data 'scheduled_event_invitees_101.json'
+      url = "#{HOST}/scheduled_events/#{@ev_uuid}/invitees"
+      add_stub_request :get, url, res_body: res_body
+
+      invs = @event.invitees
+      assert_equal 1, invs.length
+      assert_event101_invitee001 invs[0]
+    end
+
+    def test_that_it_returns_event_invitees_in_plurality_of_pages
+      ev = @event.dup
+      ev.uuid = 'EV201'
+      base_params = {
+        count: 2,
+        email: 'foobar@example.com',
+        status: 'active'
+      }
+
+      res_body1 = load_test_data 'scheduled_event_invitees_201_page1.json'
+      params1 = base_params.merge(
+        sort: 'created_at:desc'
+      )
+      url1 = "#{HOST}/scheduled_events/#{ev.uuid}/invitees?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      res_body2 = load_test_data 'scheduled_event_invitees_201_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events/#{ev.uuid}/invitees?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      invs = ev.invitees params1
+      assert_equal 3, invs.length
+      assert_event201_invitee003 invs[0]
+      assert_event201_invitee002 invs[1]
+      assert_event201_invitee001 invs[2]
+    end
+  end
+end

--- a/test/models/organization_invitation_test.rb
+++ b/test/models/organization_invitation_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::OrganizationInvitation
+  class OrganizationInvitationTest < BaseTest
+    def setup
+      super
+      org_uuid = 'ORG001'
+      org_uri = "#{HOST}/organizations/#{org_uuid}"
+      @inv_uuid = 'INV001'
+      @inv_uri = "#{org_uri}/invitations/#{@inv_uuid}"
+      attrs = { uri: @inv_uri, organization: org_uri }
+      @inv = OrganizationInvitation.new attrs, @client
+      @inv_no_client = OrganizationInvitation.new attrs
+    end
+
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @inv_no_client.fetch
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
+    def test_that_it_returns_an_associated_invitation
+      res_body = load_test_data 'organization_invitation_001.json'
+      add_stub_request :get, @inv_uri, res_body: res_body
+      assert_org_inv001 @inv.fetch
+    end
+
+    def test_that_it_deletes_self
+      add_stub_request :delete, @inv_uri, res_status: 204
+      result = @inv.delete
+      assert_equal true, result
+    end
+  end
+end

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::OrganizationMembership
+  class OrganizationMembershipTest < BaseTest
+    def setup
+      super
+      @mem_uuid = 'MEM001'
+      @mem_uri = "#{HOST}/organization_memberships/#{@mem_uuid}"
+      attrs = { uri: @mem_uri }
+      @mem = OrganizationMembership.new attrs, @client
+      @mem_no_client = OrganizationMembership.new attrs
+    end
+
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @mem_no_client.fetch
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
+    def test_that_it_returns_an_associated_membership
+      res_body = load_test_data 'organization_membership_001.json'
+      add_stub_request :get, @mem_uri, res_body: res_body
+      assert_org_mem001 @mem.fetch
+    end
+
+    def test_that_it_deletes_self
+      add_stub_request :delete, @mem_uri, res_status: 204
+      result = @mem.delete
+      assert_equal true, result
+    end
+  end
+end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::Organization
+  class OrganizationTest < BaseTest
+    def setup
+      super
+      @org_uuid = 'ORG001'
+      @org_uri = "#{HOST}/organizations/#{@org_uuid}"
+      @org_params = { organization: @org_uri }
+      attrs = { uri: @org_uri }
+      @org = Organization.new attrs, @client
+      @org_no_client = Organization.new attrs
+    end
+
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @org_no_client.memberships
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
+    def test_that_it_returns_memberships_in_single_page
+      res_body = load_test_data 'organization_memberships_001.json'
+      url = "#{HOST}/organization_memberships?#{URI.encode_www_form(@org_params)}"
+      add_stub_request :get, url, res_body: res_body
+
+      mems = @org.memberships
+      assert_equal 1, mems.length
+      assert_org_mem001 mems[0]
+    end
+
+    def test_that_it_returns_memberships_in_plurality_of_pages
+      params1 = @org_params.merge(count: 2)
+      res_body1 = load_test_data 'organization_memberships_002_page1.json'
+      url1 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      params2 = params1.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      res_body2 = load_test_data 'organization_memberships_002_page2.json'
+      url2 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      mems = @org.memberships params1
+      assert_equal 3, mems.length
+      assert_org_mem001 mems[0]
+      assert_org_mem002 mems[1]
+      assert_org_mem003 mems[2]
+    end
+
+    def test_that_it_returns_invitations_in_single_page
+      res_body = load_test_data 'organization_invitations_001.json'
+      url = "#{@org_uri}/invitations"
+      add_stub_request :get, url, res_body: res_body
+
+      invs = @org.invitations
+      assert_equal 3, invs.length
+      assert_org_inv001 invs[0]
+      assert_org_inv002 invs[1]
+      assert_org_inv003 invs[2]
+    end
+
+    def test_that_it_returns_invitations_in_plurality_of_pages
+      base_params = { count: 2 }
+      params1 = base_params.merge(sort: 'created_at:desc')
+      res_body1 = load_test_data 'organization_invitations_002_page1.json'
+      url1 = "#{@org_uri}/invitations?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      res_body2 = load_test_data 'organization_invitations_002_page2.json'
+      url2 = "#{@org_uri}/invitations?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      invs = @org.invitations params1
+      assert_equal 3, invs.length
+      assert_org_inv003 invs[0]
+      assert_org_inv002 invs[1]
+      assert_org_inv001 invs[2]
+    end
+
+    def test_that_it_creates_invitation
+      email = 'foobar@example.com'
+      req_body = { email: email }
+      res_body = load_test_data 'organization_invitation_003_create.json'
+      url = "#{@org_uri}/invitations"
+      add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
+
+      inv = @org.create_invitation email
+      assert_org_inv003 inv
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,6 +15,13 @@ module Calendly
       @user_no_client = User.new attrs
     end
 
+    def test_that_it_returns_an_error_client_is_not_ready
+      proc_client_is_blank = proc do
+        @user_no_client.fetch
+      end
+      assert_error proc_client_is_blank, '@client is not ready.'
+    end
+
     def test_that_it_returns_an_associated_user
       res_body = load_test_data 'user_001.json'
       add_stub_request :get, @user_uri, res_body: res_body

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Calendly
+  # test for Calendly::User
+  class UserTest < BaseTest
+    def setup
+      super
+      @user_uuid = 'U001'
+      @user_uri = "#{HOST}/users/#{@user_uuid}"
+      @uri_params = { user: @user_uri }
+      attrs = { uri: @user_uri }
+      @user = User.new attrs, @client
+      @user_no_client = User.new attrs
+    end
+
+    def test_that_it_returns_an_associated_user
+      res_body = load_test_data 'user_001.json'
+      add_stub_request :get, @user_uri, res_body: res_body
+      assert_user001 @user.fetch
+    end
+
+    def test_that_it_returns_an_associated_organization_membership
+      res_body = load_test_data 'organization_memberships_001.json'
+      url = "#{HOST}/organization_memberships?#{URI.encode_www_form(@uri_params)}"
+      add_stub_request :get, url, res_body: res_body
+      assert_org_mem001 @user.organization
+    end
+
+    def test_that_it_returns_event_types_in_single_page
+      res_body = load_test_data 'event_types_001.json'
+      url = "#{HOST}/event_types?#{URI.encode_www_form(@uri_params)}"
+      add_stub_request :get, url, res_body: res_body
+
+      event_types = @user.event_types
+      assert_equal 3, event_types.length
+      assert_event_type001 event_types[0]
+      assert_event_type002 event_types[1]
+      assert_event_type003 event_types[2]
+    end
+
+    def test_that_it_returns_event_types_in_plurality_of_pages
+      params1 = @uri_params.merge(count: 2, sort: 'created_at:desc')
+      url1 = "#{HOST}/event_types?#{URI.encode_www_form(params1)}"
+      res_body1 = load_test_data 'event_types_002_page1.json'
+      add_stub_request :get, url1, res_body: res_body1
+
+      params2 = @uri_params.merge(count: 2, page_token: 'NEXT_PAGE_TOKEN')
+      url2 = "#{HOST}/event_types?#{URI.encode_www_form(params2)}"
+      res_body2 = load_test_data 'event_types_002_page2.json'
+      add_stub_request :get, url2, res_body: res_body2
+
+      event_types = @user.event_types params1
+      assert_equal 3, event_types.length
+      assert_event_type003 event_types[0]
+      assert_event_type002 event_types[1]
+      assert_event_type001 event_types[2]
+    end
+
+    def test_that_it_returns_scheduled_events_in_single_page
+      res_body = load_test_data 'scheduled_events_001.json'
+      url = "#{HOST}/scheduled_events?#{URI.encode_www_form(@uri_params)}"
+      add_stub_request :get, url, res_body: res_body
+      evs = @user.scheduled_events
+      assert_equal 2, evs.length
+      assert_event001 evs[0]
+      assert_event002 evs[1]
+    end
+
+    def test_that_it_returns_scheduled_events_in_plurality_of_pages
+      base_params = @uri_params.merge(
+        count: 2,
+        invitee_email: 'foobar@example.com',
+        max_start_time: '2020-08-01T00:00:00.000000Z',
+        min_start_time: '2020-07-01T00:00:00.000000Z',
+        status: 'active'
+      )
+      res_body1 = load_test_data 'scheduled_events_002_page1.json'
+      params1 = base_params.merge(
+        sort: 'start_time:desc'
+      )
+      url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      res_body2 = load_test_data 'scheduled_events_002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      evs = @user.scheduled_events params1
+      assert_equal 3, evs.length
+      assert_event003 evs[0]
+      assert_event002 evs[1]
+      assert_event001 evs[2]
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -32,7 +32,7 @@ module Calendly
       res_body = load_test_data 'organization_memberships_001.json'
       url = "#{HOST}/organization_memberships?#{URI.encode_www_form(@uri_params)}"
       add_stub_request :get, url, res_body: res_body
-      assert_org_mem001 @user.organization
+      assert_org_mem001 @user.organization_membership
     end
 
     def test_that_it_returns_event_types_in_single_page

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,87 +16,71 @@ require 'assert_helper'
 require 'logger'
 class MyLogger < Logger; end
 
-class CalendlyBaseTest < Minitest::Test
-  include AssertHelper
+module Calendly
+  class BaseTest < Minitest::Test
+    include AssertHelper
 
-  HOST = Calendly::Client::API_HOST
+    HOST = Calendly::Client::API_HOST
 
-  def setup
-    @client_id = 'CLIENT_ID'
-    @client_secret = 'CLIENT_SECRET'
-    @token = 'TOKEN'
-    @refresh_token = 'REFRESH_TOKEN'
-    @expires_at = Time.now + 3600
-    @expired_at = Time.now - 3600
-    @my_logger = MyLogger.new STDOUT
+    def setup
+      @client_id = 'CLIENT_ID'
+      @client_secret = 'CLIENT_SECRET'
+      @token = 'TOKEN'
+      @refresh_token = 'REFRESH_TOKEN'
+      @expires_at = Time.now + 3600
+      @expired_at = Time.now - 3600
+      @my_logger = MyLogger.new STDOUT
+      @my_logger.level = :info
 
-    reset_configuration
-    @client = Calendly::Client.new @token
-  end
-
-  def init_configuration(is_expired = false)
-    Calendly.configure do |c|
-      c.client_id = @client_id
-      c.client_secret = @client_secret
-      c.token = @token
-      c.refresh_token = @refresh_token
-      c.token_expires_at = is_expired ? @expired_at : @expires_at
-      c.logger = @my_logger
+      reset_configuration
+      @client = Calendly::Client.new @token
     end
-  end
 
-  def reset_configuration
-    Calendly.configure do |c|
-      c.client_id = nil
-      c.client_secret = nil
-      c.token = nil
-      c.refresh_token = nil
-      c.token_expires_at = nil
-      c.logger = nil
+    def init_configuration(is_expired = false)
+      Calendly.configure do |c|
+        c.client_id = @client_id
+        c.client_secret = @client_secret
+        c.token = @token
+        c.refresh_token = @refresh_token
+        c.token_expires_at = is_expired ? @expired_at : @expires_at
+        c.logger = @my_logger
+      end
     end
-  end
 
-  private
-
-  def default_request_headers
-    { 'Authorization' => "Bearer #{@token}" }
-  end
-
-  def default_response_headers
-    {
-      'Content-Type' => 'application/json; charset=utf-8'
-    }
-  end
-
-  def load_test_data(filename)
-    filepath = File.join File.dirname(__FILE__), 'testdata', filename
-    File.new(filepath).read
-  end
-
-  def add_stub_request(method, url, req_headers: nil, req_body: nil, res_status: nil, res_headers: nil, res_body: nil)
-    WebMock.enable!
-    req_headers ||= default_request_headers
-    res_headers ||= default_response_headers
-    res_status ||= 200
-    stub_request(method, url).with(body: req_body, headers: req_headers).to_return(status: res_status, body: res_body, headers: res_headers)
-  end
-
-  def add_refresh_token_stub_request(is_valid = true)
-    req_params = {
-      client_id: @client_id,
-      client_secret: @client_secret,
-      grant_type: 'refresh_token',
-      refresh_token: @refresh_token
-    }
-    req_body = URI.encode_www_form(req_params)
-    if is_valid
-      res_status = 200
-      res_body = load_test_data 'refresh_token.json'
-    else
-      res_status = 400
-      res_body = load_test_data 'error_400_invalid_grant.json'
+    def reset_configuration
+      Calendly.configure do |c|
+        c.client_id = nil
+        c.client_secret = nil
+        c.token = nil
+        c.refresh_token = nil
+        c.token_expires_at = nil
+        c.logger = @my_logger
+      end
     end
-    url = "#{Calendly::Client::AUTH_API_HOST}/oauth/token"
-    stub_request(:post, url).with(body: req_body).to_return(status: res_status, body: res_body, headers: default_response_headers)
+
+    private
+
+    def default_request_headers
+      { 'Authorization' => "Bearer #{@token}" }
+    end
+
+    def default_response_headers
+      {
+        'Content-Type' => 'application/json; charset=utf-8'
+      }
+    end
+
+    def load_test_data(filename)
+      filepath = File.join File.dirname(__FILE__), 'testdata', filename
+      File.new(filepath).read
+    end
+
+    def add_stub_request(method, url, req_headers: nil, req_body: nil, res_status: nil, res_headers: nil, res_body: nil)
+      WebMock.enable!
+      req_headers ||= default_request_headers
+      res_headers ||= default_response_headers
+      res_status ||= 200
+      stub_request(method, url).with(body: req_body, headers: req_headers).to_return(status: res_status, body: res_body, headers: res_headers)
+    end
   end
 end


### PR DESCRIPTION
- define methods to access associated resources with each model.
- rename methods:
  - `Calendly::Client#events` to `Calendly::Client#scheduled_events`
