### PR TITLE
add cancel and reschedule url fields to Invitee model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.4.2
+
+- add new following fields to Invitee model (refs #21)
+  - :rescheduled
+  - :old_invitee
+  - :new_invitee
+  - :cancel_url
+  - :reschedule_url
+
 ## 0.4.1
 
 - support API

--- a/lib/calendly/models/invitee.rb
+++ b/lib/calendly/models/invitee.rb
@@ -34,6 +34,22 @@ module Calendly
     # @return [String]
     # Text (SMS) reminder phone number.
     attr_accessor :text_reminder_number
+    # @return [Boolean]
+    # Indicates if this invitee has rescheduled.
+    # If true, a reference to the new Invitee instance is provided in the new_invitee field.
+    attr_accessor :rescheduled
+    # @return [String, nil]
+    # Reference to old Invitee instance that got rescheduled.
+    attr_accessor :old_invitee
+    # @return [String, nil]
+    # Link to new invitee, after reschedule.
+    attr_accessor :new_invitee
+    # @return [String]
+    # Link to cancelling the event for the invitee.
+    attr_accessor :cancel_url
+    # @return [String]
+    # Link to rescheduling the event for the invitee.
+    attr_accessor :reschedule_url
     # @return [Time]
     # Moment when user record was first created.
     attr_accessor :created_at

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Calendly
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -245,6 +245,11 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV101', inv.event.uri
     assert_equal 'EV101', inv.event.uuid
     assert_nil inv.text_reminder_number
+    assert_equal false, inv.rescheduled
+    assert_nil inv.old_invitee
+    assert_nil inv.new_invitee
+    assert_equal 'https://calendly.com/cancellations/INV001', inv.cancel_url
+    assert_equal 'https://calendly.com/reschedulings/INV001', inv.reschedule_url
     assert_equal Time.parse('2020-08-20T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-20T01:30:00.000000Z').to_i, inv.updated_at.to_i
 
@@ -295,6 +300,11 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
     assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
+    assert_equal false, inv.rescheduled
+    assert_nil inv.old_invitee
+    assert_nil inv.new_invitee
+    assert_equal 'https://calendly.com/cancellations/INV001', inv.cancel_url
+    assert_equal 'https://calendly.com/reschedulings/INV001', inv.reschedule_url
     assert_equal Time.parse('2020-08-01T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-01T01:30:00.000000Z').to_i, inv.updated_at.to_i
 
@@ -330,6 +340,11 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
     assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
+    assert_equal false, inv.rescheduled
+    assert_equal 'https://api.calendly.com/scheduled_events/EV201_OLD1/invitees/INV002', inv.old_invitee
+    assert_nil inv.new_invitee
+    assert_equal 'https://calendly.com/cancellations/INV002', inv.cancel_url
+    assert_equal 'https://calendly.com/reschedulings/INV002', inv.reschedule_url
     assert_equal Time.parse('2020-08-02T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-02T01:30:00.000000Z').to_i, inv.updated_at.to_i
 
@@ -365,6 +380,11 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/scheduled_events/EV201', inv.event.uri
     assert_equal 'EV201', inv.event.uuid
     assert_nil inv.text_reminder_number
+    assert_equal false, inv.rescheduled
+    assert_nil inv.old_invitee
+    assert_nil inv.new_invitee
+    assert_equal 'https://calendly.com/cancellations/INV003', inv.cancel_url
+    assert_equal 'https://calendly.com/reschedulings/INV003', inv.reschedule_url
     assert_equal Time.parse('2020-08-03T01:00:00.000000Z').to_i, inv.created_at.to_i
     assert_equal Time.parse('2020-08-03T01:30:00.000000Z').to_i, inv.updated_at.to_i
 
@@ -386,6 +406,61 @@ module AssertHelper
     assert_equal 'FOOBAR_CONTENT_3', tracking.utm_content
     assert_equal 'FOOBAR_TERM_3', tracking.utm_term
     assert_equal 'FOOBAR_SALESFORCE_UUID_3', tracking.salesforce_uuid
+  end
+
+  def assert_event301_invitee001(inv)
+    assert inv.client.is_a? Calendly::Client
+    assert_equal 'INV001', inv.id
+    assert_equal 'INV001', inv.uuid
+    assert_equal 'https://api.calendly.com/scheduled_events/EV301/invitees/INV001', inv.uri
+    assert_equal 'foobar@example.com', inv.email
+    assert_equal 'FooBar', inv.name
+    assert_equal 'canceled', inv.status
+    assert_equal 'Asia/Tokyo', inv.timezone
+    assert_equal 'https://api.calendly.com/scheduled_events/EV301', inv.event.uri
+    assert_equal 'EV301', inv.event.uuid
+    assert_equal '12345678', inv.text_reminder_number
+    assert_equal true, inv.rescheduled
+    assert_equal 'https://api.calendly.com/scheduled_events/EV301_OLD1/invitees/INV001', inv.old_invitee
+    assert_equal 'https://api.calendly.com/scheduled_events/EV301_NEW1/invitees/INV001', inv.new_invitee
+    assert_equal 'https://calendly.com/cancellations/INV001', inv.cancel_url
+    assert_equal 'https://calendly.com/reschedulings/INV001', inv.reschedule_url
+    assert_equal Time.parse('2020-08-20T01:00:00.000000Z').to_i, inv.created_at.to_i
+    assert_equal Time.parse('2020-08-20T01:30:00.000000Z').to_i, inv.updated_at.to_i
+
+    assert_equal 5, inv.questions_and_answers.length
+    qa = inv.questions_and_answers[0]
+    assert_equal "text1\ntext2\ntext3", qa.answer
+    assert_equal 0, qa.position
+    assert_equal 'Multiple Lines Question', qa.question
+
+    qa = inv.questions_and_answers[1]
+    assert_equal 'text1', qa.answer
+    assert_equal 1, qa.position
+    assert_equal 'One Line Question', qa.question
+
+    qa = inv.questions_and_answers[2]
+    assert_equal 'A1', qa.answer
+    assert_equal 2, qa.position
+    assert_equal 'Radio Buttons Question', qa.question
+
+    qa = inv.questions_and_answers[3]
+    assert_equal "A1\nOther", qa.answer
+    assert_equal 3, qa.position
+    assert_equal 'Checkboxes Question', qa.question
+
+    qa = inv.questions_and_answers[4]
+    assert_equal '+81 70-1234-5678', qa.answer
+    assert_equal 4, qa.position
+    assert_equal 'Phone Number Question', qa.question
+
+    tracking = inv.tracking
+    assert_equal 'FOOBAR_CAMPAIGN', tracking.utm_campaign
+    assert_equal 'FOOBAR_SOURCE', tracking.utm_source
+    assert_equal 'FOOBAR_MEDIUM', tracking.utm_medium
+    assert_equal 'FOOBAR_CONTENT', tracking.utm_content
+    assert_equal 'FOOBAR_TERM', tracking.utm_term
+    assert_equal 'FOOBAR_SALESFORCE_UUID', tracking.salesforce_uuid
   end
 
   def assert_location_tokyo(loc)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -282,13 +282,13 @@ module Calendly
     def test_that_it_returns_a_one_on_one_event_invitee
       ev_uuid = 'EV101'
       inv_uuid = 'INV001'
-      res_body = load_test_data 'scheduled_event_invitee_101.json'
+      res_body = load_test_data 'scheduled_event_invitee_301.json'
 
       url = "#{HOST}/scheduled_events/#{ev_uuid}/invitees/#{inv_uuid}"
       add_stub_request :get, url, res_body: res_body
 
       inv = @client.event_invitee ev_uuid, inv_uuid
-      assert_event101_invitee001 inv
+      assert_event301_invitee001 inv
     end
 
     def test_that_it_raises_an_argument_error_on_event_invitee

--- a/test/models/event_invitee_test.rb
+++ b/test/models/event_invitee_test.rb
@@ -29,9 +29,9 @@ module Calendly
     end
 
     def test_that_it_returns_an_associated_invitee
-      res_body = load_test_data 'scheduled_event_invitee_101.json'
+      res_body = load_test_data 'scheduled_event_invitee_301.json'
       add_stub_request :get, @inv_uri, res_body: res_body
-      assert_event101_invitee001 @invitee.fetch
+      assert_event301_invitee001 @invitee.fetch
     end
   end
 end

--- a/test/testdata/scheduled_event_invitee_301.json
+++ b/test/testdata/scheduled_event_invitee_301.json
@@ -1,9 +1,12 @@
 {
   "resource": {
+    "cancel_url": "https://calendly.com/cancellations/INV001",
     "created_at": "2020-08-20T01:00:00.000000Z",
     "email": "foobar@example.com",
-    "event": "https://api.calendly.com/scheduled_events/EV101",
+    "event": "https://api.calendly.com/scheduled_events/EV301",
     "name": "FooBar",
+    "new_invitee": "https://api.calendly.com/scheduled_events/EV301_NEW1/invitees/INV001",
+    "old_invitee": "https://api.calendly.com/scheduled_events/EV301_OLD1/invitees/INV001",
     "questions_and_answers": [
       {
         "answer": "text1\ntext2\ntext3",
@@ -31,8 +34,10 @@
         "question": "Phone Number Question"
       }
     ],
-    "status": "active",
-    "text_reminder_number": null,
+    "reschedule_url": "https://calendly.com/reschedulings/INV001",
+    "rescheduled": true,
+    "status": "canceled",
+    "text_reminder_number": "12345678",
     "timezone": "Asia/Tokyo",
     "tracking": {
       "utm_campaign": "FOOBAR_CAMPAIGN",
@@ -43,6 +48,6 @@
       "salesforce_uuid": "FOOBAR_SALESFORCE_UUID"
     },
     "updated_at": "2020-08-20T01:30:00.000000Z",
-    "uri": "https://api.calendly.com/scheduled_events/EV101/invitees/INV001"
+    "uri": "https://api.calendly.com/scheduled_events/EV301/invitees/INV001"
   }
 }

--- a/test/testdata/scheduled_event_invitees_101.json
+++ b/test/testdata/scheduled_event_invitees_101.json
@@ -1,10 +1,13 @@
 {
   "collection": [
     {
+      "cancel_url": "https://calendly.com/cancellations/INV001",
       "created_at": "2020-08-20T01:00:00.000000Z",
       "email": "foobar@example.com",
       "event": "https://api.calendly.com/scheduled_events/EV101",
       "name": "FooBar",
+      "new_invitee": null,
+      "old_invitee": null,
       "questions_and_answers": [
         {
           "answer": "text1\ntext2\ntext3",
@@ -32,6 +35,8 @@
           "question": "Phone Number Question"
         }
       ],
+      "reschedule_url": "https://calendly.com/reschedulings/INV001",
+      "rescheduled": false,
       "status": "active",
       "text_reminder_number": null,
       "timezone": "Asia/Tokyo",

--- a/test/testdata/scheduled_event_invitees_201_page1.json
+++ b/test/testdata/scheduled_event_invitees_201_page1.json
@@ -1,10 +1,13 @@
 {
   "collection": [
     {
+      "cancel_url": "https://calendly.com/cancellations/INV003",
       "created_at": "2020-08-03T01:00:00.000000Z",
       "email": "foobar@example.com",
       "event": "https://api.calendly.com/scheduled_events/EV201",
       "name": "FooBar",
+      "new_invitee": null,
+      "old_invitee": null,
       "questions_and_answers": [
         {
           "answer": "A3",
@@ -17,6 +20,8 @@
           "question": "Checkboxes Question"
         }
       ],
+      "reschedule_url": "https://calendly.com/reschedulings/INV003",
+      "rescheduled": false,
       "status": "active",
       "text_reminder_number": null,
       "timezone": "Asia/Tokyo",
@@ -32,10 +37,13 @@
       "uri": "https://api.calendly.com/scheduled_events/EV201/invitees/INV003"
     },
     {
+      "cancel_url": "https://calendly.com/cancellations/INV002",
       "created_at": "2020-08-02T01:00:00.000000Z",
       "email": "foobar@example.com",
       "event": "https://api.calendly.com/scheduled_events/EV201",
       "name": "FooBar",
+      "new_invitee": null,
+      "old_invitee": "https://api.calendly.com/scheduled_events/EV201_OLD1/invitees/INV002",
       "questions_and_answers": [
         {
           "answer": "A2",
@@ -48,6 +56,8 @@
           "question": "Checkboxes Question"
         }
       ],
+      "reschedule_url": "https://calendly.com/reschedulings/INV002",
+      "rescheduled": false,
       "status": "active",
       "text_reminder_number": null,
       "timezone": "Asia/Tokyo",

--- a/test/testdata/scheduled_event_invitees_201_page2.json
+++ b/test/testdata/scheduled_event_invitees_201_page2.json
@@ -1,10 +1,13 @@
 {
   "collection": [
     {
+      "cancel_url": "https://calendly.com/cancellations/INV001",
       "created_at": "2020-08-01T01:00:00.000000Z",
       "email": "foobar@example.com",
       "event": "https://api.calendly.com/scheduled_events/EV201",
       "name": "FooBar",
+      "new_invitee": null,
+      "old_invitee": null,
       "questions_and_answers": [
         {
           "answer": "A1",
@@ -17,6 +20,8 @@
           "question": "Checkboxes Question"
         }
       ],
+      "reschedule_url": "https://calendly.com/reschedulings/INV001",
+      "rescheduled": false,
       "status": "active",
       "text_reminder_number": null,
       "timezone": "Asia/Tokyo",


### PR DESCRIPTION
- add new following fields to Invitee model (refs #21)
  - :rescheduled
  - :old_invitee
  - :new_invitee
  - :cancel_url
  - :reschedule_url