### PR TITLE
support an organization option of scheduled events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.5.0
+
+- changed Calendly::Client#scheduled_events behavior (refs #21)
+  - previous version:
+    - getting events belonging to a specific USER
+  - current version:
+    - getting all events belonging to a specific ORGANIZATION
+- added Calendly::Client#scheduled_events_by_user method instead_of the before behavior
+
 ## 0.4.2
 
 - added new following fields to Invitee model (refs #21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.2
 
-- add new following fields to Invitee model (refs #21)
+- added new following fields to Invitee model (refs #21)
   - :rescheduled
   - :old_invitee
   - :new_invitee
@@ -11,20 +11,20 @@
 
 ## 0.4.1
 
-- support API
+- started to support a API
   - `GET /event_types/{uuid}`
 
 ## 0.4.0
 
-- fix changed Location fields such as `kind` to `type`. (refs #18)
+- fixed a changes for Location fields such as `kind` to `type`. (refs #18)
 
 ## 0.3.0
 
-- remove zeitwerk dependency. (refs #16)
+- removed zeitwerk dependency. (refs #16)
 
 ## 0.2.0
 
-- save fetched data in cache. (refs #14)
+- added caching features in object when fetching data. (refs #14)
 
 ## 0.1.3
 
@@ -36,59 +36,59 @@
 
 ## 0.1.2
 
-- fix rubocop warnings.
+- fixed rubocop warnings.
 
 ## 0.1.1
 
-- add tests to make coverage 100%.
+- added tests to make coverage 100%.
 
 ## 0.1.0
 
-- define methods to access associated resources with each model.
-- rename methods:
+- defined methods to access associated resources with each model.
+- renamed methods:
   - `Calendly::Client#events` to `Calendly::Client#scheduled_events`
 
 ## 0.0.7.alpha
 
-- support APIs
+- started to support APIs
   - `POST /organizations/{uuid}/invitations`
   - `DELETE /organizations/{org_uuid}/invitations/{invitation_uuid}`
   - `DELETE /organization_memberships/{uuid}`
 
 ## 0.0.6.alpha
 
-- support APIs
+- started to support APIs
   - `GET /organizations/{uuid}/invitations`
   - `GET /organizations/{organization_uuid}/invitations/{invitation_uuid}`
 
 ## 0.0.5.alpha
 
-- support APIs
+- started to support APIs
   - `GET /organization_memberships`
   - `GET /organization_memberships/{uuid}`
-- rename fields
+- renamed fields
   - Invitee#event to Invitee#event_uri
   - Event#event_type to Event#event_type_uri
 
 ## 0.0.4.alpha
 
-- support APIs
+- started to support APIs
   - `GET /scheduled_events/{event_uuid}/invitees`
   - `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`
 
 ## 0.0.3.alpha
 
-- support APIs
+- started to support APIs
   - `GET /scheduled_events`
   - `GET /scheduled_events/{uuid}`
 
 ## 0.0.2.alpha
 
-- support APIs
+- started to support APIs
   - `GET /event_types`
 
 ## 0.0.1.alpha
 
 - Initial release
-- support APIs
+- started to support a API
   - `GET /users/{uuid}`

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -144,7 +144,38 @@ module Calendly
     end
 
     #
-    # Get List of User Events.
+    # Get List of scheduled events belonging to a specific organization.
+    #
+    # @param [String] org_uri the specified organization (organization's uri).
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email.
+    # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Whether the scheduled event is active or canceled.
+    # @return [Array<Array<Calendly::Event>, Hash>]
+    #  - [Array<Calendly::Event>] events
+    #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
+    # @raise [Calendly::Error] if the org_uri arg is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.5.0
+    def scheduled_events(org_uri, opts = {})
+      check_not_empty org_uri, 'org_uri'
+
+      opts_keys = %i[count invitee_email max_start_time min_start_time page_token sort status]
+      params = {organization: org_uri}
+      params = merge_options opts, opts_keys, params
+      body = request :get, 'scheduled_events', params: params
+
+      items = body[:collection] || []
+      evs = items.map { |item| Event.new item, self }
+      [evs, next_page_params(body)]
+    end
+
+    #
+    # Get List of scheduled events belonging to a specific user.
     #
     # @param [String] user_uri the specified user (user's uri).
     # @param [Hash] opts the optional request parameters.
@@ -161,7 +192,7 @@ module Calendly
     # @raise [Calendly::Error] if the user_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.3
-    def scheduled_events(user_uri, opts = {})
+    def scheduled_events_by_user(user_uri, opts = {})
       check_not_empty user_uri, 'user_uri'
 
       opts_keys = %i[count invitee_email max_start_time min_start_time page_token sort status]
@@ -235,7 +266,7 @@ module Calendly
     end
 
     #
-    # Get List memberships of all users belonging to an organization.
+    # Get List of memberships belonging to specific an organization.
     #
     # @param [String] org_uri the specified organization (organization's uri).
     # @param [Hash] opts the optional request parameters.
@@ -262,7 +293,7 @@ module Calendly
     end
 
     #
-    # Get List memberships of all users belonging to an organization by user.
+    # Get List of memberships belonging to specific a user.
     #
     # @param [String] user_uri the specified user (user's uri).
     # @param [Hash] opts the optional request parameters.

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -179,6 +179,7 @@ module Calendly
     #
     # @param [String] user_uri the specified user (user's uri).
     # @param [Hash] opts the optional request parameters.
+    # @option opts [String] :organization the specified organization (organization's uri).
     # @option opts [Integer] :count Number of rows to return.
     # @option opts [String] :invitee_email Return events scheduled with the specified invitee email.
     # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
@@ -195,7 +196,7 @@ module Calendly
     def scheduled_events_by_user(user_uri, opts = {})
       check_not_empty user_uri, 'user_uri'
 
-      opts_keys = %i[count invitee_email max_start_time min_start_time page_token sort status]
+      opts_keys = %i[organization count invitee_email max_start_time min_start_time page_token sort status]
       params = {user: user_uri}
       params = merge_options opts, opts_keys, params
       body = request :get, 'scheduled_events', params: params

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -81,6 +81,35 @@ module Calendly
     end
 
     #
+    # Returns all Scheduled Events associated with self.
+    #
+    # @param [Hash] opts the optional request parameters.
+    # @option opts [Integer] :count Number of rows to return.
+    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email
+    # @option opts [String] :max_start_timeUpper bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @option opts [String] :sort Order results by the specified field and directin.
+    # Accepts comma-separated list of {field}:{direction} values.
+    # @option opts [String] :status Whether the scheduled event is active or canceled
+    # @return [Array<Calendly::Event>]
+    # @raise [Calendly::Error] if the uri is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.5.0
+    def scheduled_events(opts = {})
+      return @cached_scheduled_events if @cached_scheduled_events
+
+      request_proc = proc { |options| client.scheduled_events uri, options }
+      @cached_scheduled_events = auto_pagination request_proc, opts
+    end
+
+    # @since 0.5.0
+    def scheduled_events!(opts = {})
+      @cached_scheduled_events = nil
+      scheduled_events opts
+    end
+
+    #
     # Get List of organization scope Webhooks associated with self.
     #
     # @param [Hash] opts the optional request parameters.

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -116,7 +116,7 @@ module Calendly
     def scheduled_events(opts = {})
       return @cached_scheduled_events if @cached_scheduled_events
 
-      request_proc = proc { |options| client.scheduled_events uri, options }
+      request_proc = proc { |options| client.scheduled_events_by_user uri, options }
       @cached_scheduled_events = auto_pagination request_proc, opts
     end
 

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Calendly
-  VERSION = '0.4.2'
+  VERSION = '0.5.0'
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -215,29 +215,29 @@ module Calendly
     # test for scheduled_events
     #
 
-    def test_that_it_returns_all_items_of_event
-      user_uri = 'https://api.calendly.com/users/U001'
+    def test_that_it_returns_all_items_of_org_event
+      org_uri = 'https://api.calendly.com/organizations/ORG001'
       res_body = load_test_data 'scheduled_events_001.json'
-      params = {user: user_uri}
+      params = {organization: org_uri}
 
       url = "#{HOST}/scheduled_events?#{URI.encode_www_form(params)}"
       add_stub_request :get, url, res_body: res_body
 
-      evs, next_params = @client.scheduled_events user_uri
+      evs, next_params = @client.scheduled_events org_uri
       assert_equal 2, evs.length
       assert_nil next_params
       assert_event001 evs[0]
       assert_event002 evs[1]
     end
 
-    def test_that_it_returns_all_items_of_event_by_pagination
-      user_uri = 'https://api.calendly.com/users/U001'
+    def test_that_it_returns_all_items_of_org_event_by_pagination
+      org_uri = 'https://api.calendly.com/organizations/ORG001'
       base_params = {
         count: 2,
         invitee_email: 'foobar@example.com',
         max_start_time: '2020-08-01T00:00:00.000000Z',
         min_start_time: '2020-07-01T00:00:00.000000Z',
-        user: user_uri,
+        organization: org_uri,
         status: 'active'
       }
       res_body1 = load_test_data 'scheduled_events_002_page1.json'
@@ -255,10 +255,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      evs_page1, next_params1 = @client.scheduled_events user_uri, params1
-      user_uri = next_params1.delete :user
+      evs_page1, next_params1 = @client.scheduled_events org_uri, params1
+      # org_uri = next_params1.delete :organization
       # request page2
-      evs_page2, next_params2 = @client.scheduled_events user_uri, next_params1
+      evs_page2, next_params2 = @client.scheduled_events org_uri, next_params1
 
       assert_equal 2, evs_page1.length
       assert_equal 1, evs_page2.length
@@ -268,9 +268,73 @@ module Calendly
       assert_event011 evs_page2[0]
     end
 
-    def test_that_it_raises_an_argument_error_on_events
+    def test_that_it_raises_an_argument_error_on_scheduled_events
       proc_arg_is_empty = proc do
         @client.scheduled_events ''
+      end
+      assert_required_error proc_arg_is_empty, 'org_uri'
+    end
+
+    #
+    # test for scheduled_events_by_user
+    #
+
+    def test_that_it_returns_all_items_of_user_event
+      user_uri = 'https://api.calendly.com/users/U001'
+      res_body = load_test_data 'scheduled_events_u001.json'
+      params = {user: user_uri}
+
+      url = "#{HOST}/scheduled_events?#{URI.encode_www_form(params)}"
+      add_stub_request :get, url, res_body: res_body
+
+      evs, next_params = @client.scheduled_events_by_user user_uri
+      assert_equal 2, evs.length
+      assert_nil next_params
+      assert_event001 evs[0]
+      assert_event002 evs[1]
+    end
+
+    def test_that_it_returns_all_items_of_user_event_by_pagination
+      user_uri = 'https://api.calendly.com/users/U001'
+      base_params = {
+        count: 2,
+        invitee_email: 'foobar@example.com',
+        max_start_time: '2020-08-01T00:00:00.000000Z',
+        min_start_time: '2020-07-01T00:00:00.000000Z',
+        user: user_uri,
+        status: 'active'
+      }
+      res_body1 = load_test_data 'scheduled_events_u002_page1.json'
+      params1 = base_params.merge(
+        sort: 'start_time:desc'
+      )
+      url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      res_body2 = load_test_data 'scheduled_events_u002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      # request page1
+      evs_page1, next_params1 = @client.scheduled_events_by_user user_uri, params1
+      user_uri = next_params1.delete :user
+      # request page2
+      evs_page2, next_params2 = @client.scheduled_events_by_user user_uri, next_params1
+
+      assert_equal 2, evs_page1.length
+      assert_equal 1, evs_page2.length
+      assert_nil next_params2
+      assert_event013 evs_page1[0]
+      assert_event012 evs_page1[1]
+      assert_event011 evs_page2[0]
+    end
+
+    def test_that_it_raises_an_argument_error_on_scheduled_events_by_user
+      proc_arg_is_empty = proc do
+        @client.scheduled_events_by_user ''
       end
       assert_required_error proc_arg_is_empty, 'user_uri'
     end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -118,6 +118,55 @@ module Calendly
       assert_org_inv003 inv
     end
 
+    def test_that_it_returns_scheduled_events_in_single_page
+      res_body = load_test_data 'scheduled_events_001.json'
+      url = "#{HOST}/scheduled_events?#{URI.encode_www_form(@org_params)}"
+      add_stub_request :get, url, res_body: res_body
+
+      assert_evs = proc do |evs|
+        assert_equal 2, evs.length
+        assert_event001 evs[0]
+        assert_event002 evs[1]
+      end
+      assert_evs.call @org.scheduled_events
+
+      # test the fetched data should save in cache.
+      WebMock.reset!
+      assert_evs.call @org.scheduled_events
+
+      add_stub_request :get, url, res_body: res_body
+      assert_evs.call @org.scheduled_events!
+    end
+
+    def test_that_it_returns_scheduled_events_in_plurality_of_pages
+      base_params = @org_params.merge(
+        count: 2,
+        invitee_email: 'foobar@example.com',
+        max_start_time: '2020-08-01T00:00:00.000000Z',
+        min_start_time: '2020-07-01T00:00:00.000000Z',
+        status: 'active'
+      )
+      res_body1 = load_test_data 'scheduled_events_002_page1.json'
+      params1 = base_params.merge(
+        sort: 'start_time:desc'
+      )
+      url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
+      add_stub_request :get, url1, res_body: res_body1
+
+      res_body2 = load_test_data 'scheduled_events_002_page2.json'
+      params2 = base_params.merge(
+        page_token: 'NEXT_PAGE_TOKEN'
+      )
+      url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
+      add_stub_request :get, url2, res_body: res_body2
+
+      evs = @org.scheduled_events params1
+      assert_equal 3, evs.length
+      assert_event013 evs[0]
+      assert_event012 evs[1]
+      assert_event011 evs[2]
+    end
+
     def test_that_it_returns_webhooks_in_single_page
       res_body = load_test_data 'webhooks_organization_001.json'
       params = {

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -86,7 +86,7 @@ module Calendly
     end
 
     def test_that_it_returns_scheduled_events_in_single_page
-      res_body = load_test_data 'scheduled_events_001.json'
+      res_body = load_test_data 'scheduled_events_u001.json'
       url = "#{HOST}/scheduled_events?#{URI.encode_www_form(@uri_params)}"
       add_stub_request :get, url, res_body: res_body
 
@@ -113,14 +113,14 @@ module Calendly
         min_start_time: '2020-07-01T00:00:00.000000Z',
         status: 'active'
       )
-      res_body1 = load_test_data 'scheduled_events_002_page1.json'
+      res_body1 = load_test_data 'scheduled_events_u002_page1.json'
       params1 = base_params.merge(
         sort: 'start_time:desc'
       )
       url1 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params1)}"
       add_stub_request :get, url1, res_body: res_body1
 
-      res_body2 = load_test_data 'scheduled_events_002_page2.json'
+      res_body2 = load_test_data 'scheduled_events_u002_page2.json'
       params2 = base_params.merge(
         page_token: 'NEXT_PAGE_TOKEN'
       )

--- a/test/testdata/scheduled_events_u001.json
+++ b/test/testdata/scheduled_events_u001.json
@@ -1,0 +1,43 @@
+{
+  "collection": [
+    {
+      "created_at": "2020-07-10T05:00:00.000000Z",
+      "end_time": "2020-07-22T02:00:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET001",
+      "invitees_counter": {
+        "active": 0,
+        "limit": 5,
+        "total": 1
+      },
+      "location": null,
+      "name": "30 Minute Meeting",
+      "start_time": "2020-07-22T01:30:00.000000Z",
+      "status": "canceled",
+      "updated_at": "2020-07-11T06:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV001"
+    },
+    {
+      "created_at": "2020-07-10T06:00:00.000000Z",
+      "end_time": "2020-07-23T01:30:00.000000Z",
+      "event_type": "https://api.calendly.com/event_types/ET002",
+      "invitees_counter": {
+        "active": 1,
+        "limit": 1,
+        "total": 1
+      },
+      "location": {
+        "location": "Tokyo",
+        "type": "physical"
+      },
+      "name": "15 Minute Meeting",
+      "start_time": "2020-07-23T01:15:00.000000Z",
+      "status": "active",
+      "updated_at": "2020-07-10T07:00:00.000000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV002"
+    }
+  ],
+  "pagination": {
+    "count": 2,
+    "next_page": null
+  }
+}

--- a/test/testdata/scheduled_events_u002_page1.json
+++ b/test/testdata/scheduled_events_u002_page1.json
@@ -52,6 +52,6 @@
   ],
   "pagination": {
     "count": 2,
-    "next_page": "https://api.calendly.com/scheduled_events?count=2&invitee_email=foobar%40example.com&max_start_time=2020-08-01T00%3A00%3A00.000000Z&min_start_time=2020-07-01T00%3A00%3A00.000000Z&page_token=NEXT_PAGE_TOKEN&status=active&organization=https%3A%2F%2Fapi.calendly.com%2Forganizations%2FORG001"
+    "next_page": "https://api.calendly.com/scheduled_events?count=2&invitee_email=foobar%40example.com&max_start_time=2020-08-01T00%3A00%3A00.000000Z&min_start_time=2020-07-01T00%3A00%3A00.000000Z&page_token=NEXT_PAGE_TOKEN&status=active&user=https%3A%2F%2Fapi.calendly.com%2Fusers%2FU001"
   }
 }

--- a/test/testdata/scheduled_events_u002_page2.json
+++ b/test/testdata/scheduled_events_u002_page2.json
@@ -1,0 +1,35 @@
+{
+  "collection": [
+    {
+      "created_at": "2020-07-10T05:00:00.000Z",
+      "end_time": "2020-07-22T02:00:00.000Z",
+      "event_type": "https://api.calendly.com/event_types/ET001",
+      "invitees_counter": {
+        "active": 0,
+        "limit": 5,
+        "total": 1
+      },
+      "location": {
+        "data": {
+          "audioConferencing": {
+            "conferenceId": "foobar-conferenceId",
+            "dialinUrl": "foobar-dialinUrl",
+            "tollNumber": "foobar-tollNumber"
+          }
+        },
+        "join_url": "https://calendly.com/events/xxx/microsoft_teams",
+        "status": "pushed",
+        "type": "microsoft_teams_conference"
+      },
+      "name": "30 Minute Meeting",
+      "start_time": "2020-07-22T01:30:00.000Z",
+      "status": "canceled",
+      "updated_at": "2020-07-11T06:00:00.000Z",
+      "uri": "https://api.calendly.com/scheduled_events/EV011"
+    }
+  ],
+  "pagination": {
+    "count": 1,
+    "next_page": null
+  }
+}


### PR DESCRIPTION
- changed Calendly::Client#scheduled_events behavior (refs #21)
  - previous version:
    - getting events belonging to a specific USER
  - current version:
    - getting all events belonging to a specific ORGANIZATION
- added Calendly::Client#scheduled_events_by_user method instead_of the before behavior
