### PR TITLE
refs #25 support create scheduling link API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.5.2
+
+- started to support a API
+  - `POST /scheduling_links`
+
 ## 0.5.1
 
 - added method EventType#fetch

--- a/lib/calendly/models/event_type.rb
+++ b/lib/calendly/models/event_type.rb
@@ -86,6 +86,25 @@ module Calendly
       client.event_type uuid
     end
 
+    #
+    # Create an associated scheduling link.
+    #
+    # @param [String] max_event_count The max number of events that can be scheduled using this scheduling link.
+    # @return [Hash]
+    # e.g.
+    # {
+    #   booking_url: "https://calendly.com/s/FOO-BAR-SLUG",
+    #   owner: "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2",
+    #   owner_type: "EventType"
+    # }
+    # @raise [Calendly::Error] if the uri is empty.
+    # @raise [Calendly::Error] if the max_event_count arg is empty.
+    # @raise [Calendly::ApiError] if the api returns error code.
+    # @since 0.5.2
+    def create_schedule_link(max_event_count = 1)
+      client.create_schedule_link uri, max_event_count, resource_type: 'EventType'
+    end
+
   private
 
     def after_set_attributes(attrs)

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Calendly
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -702,6 +702,15 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/users/U001', webhook.creator.uri
   end
 
+  def assert_schedule_link_001(s_link)
+    expected = {
+      booking_url: "https://calendly.com/s/FOO-BAR-SLUG",
+      owner: "https://api.calendly.com/event_types/ET001",
+      owner_type: "EventType"
+    }
+    assert_equal expected, s_link
+  end
+
   def assert_error(proc, ex_message)
     e = assert_raises Calendly::Error do
       proc.call

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -931,6 +931,42 @@ module Calendly
       assert_api_error proc_error, 400, res_body
     end
 
+    #
+    # test for create_schedule_link
+    #
+
+    def test_that_it_creates_schedule_link
+      max_event_count = 1
+      resource_uri = "#{HOST}/resource/0001"
+      resource_type = 'FooBar'
+      req_body = {
+        max_event_count: max_event_count,
+        owner: resource_uri,
+        owner_type: resource_type
+      }
+      res_body = load_test_data 'schedule_link_001.json'
+      url = "#{HOST}/scheduling_links"
+      add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
+      assert_schedule_link_001 @client.create_schedule_link(resource_uri, resource_type: resource_type)
+    end
+
+    def test_that_it_raises_an_argument_error_on_create_schedule_link
+      proc_uri_arg_is_empty = proc do
+        @client.create_schedule_link ''
+      end
+      assert_required_error proc_uri_arg_is_empty, 'uri'
+
+      proc_max_event_count_arg_is_empty = proc do
+        @client.create_schedule_link 'uri', nil
+      end
+      assert_required_error proc_max_event_count_arg_is_empty, 'max_event_count'
+
+      proc_resource_type_arg_is_empty = proc do
+        @client.create_schedule_link 'uri', resource_type: nil
+      end
+      assert_required_error proc_resource_type_arg_is_empty, 'resource_type'
+    end
+
   private
 
     def add_refresh_token_stub_request(is_valid = true)

--- a/test/models/event_type_test.rb
+++ b/test/models/event_type_test.rb
@@ -30,5 +30,17 @@ module Calendly
       add_stub_request :get, @et_uri, res_body: res_body
       assert_event_type001 @event_type.fetch
     end
+
+    def test_that_it_creates_schedule_link
+      req_body = {
+        max_event_count: 3,
+        owner: @et_uri,
+        owner_type: 'EventType'
+      }
+      res_body = load_test_data 'schedule_link_001.json'
+      url = "#{HOST}/scheduling_links"
+      add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
+      assert_schedule_link_001 @event_type.create_schedule_link(3)
+    end
   end
 end

--- a/test/testdata/schedule_link_001.json
+++ b/test/testdata/schedule_link_001.json
@@ -1,0 +1,7 @@
+{
+  "resource": {
+    "booking_url": "https://calendly.com/s/FOO-BAR-SLUG",
+    "owner": "https://api.calendly.com/event_types/ET001",
+    "owner_type": "EventType"
+  }
+}


### PR DESCRIPTION
refs #25

- started to support a API
  - `POST /scheduling_links`