### PR TITLE
Use keyword arguments for optional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # CHANGELOG
 
+## 0.8.0
+
+- used keyword arguments for optional parameters, to be friendly for programmer.
+- changed methods are followings:
+  - Client
+    - event_types
+    - event_types_by_user
+    - scheduled_events
+    - scheduled_events_by_user
+    - event_invitees
+    - memberships
+    - memberships_by_user
+    - invitations
+    - webhooks
+    - user_scope_webhooks
+    - create_schedule_link
+  - Event
+    - invitees
+    - invitees!
+  - EventType
+    - create_schedule_link
+  - Organization
+    - memberships
+    - memberships!
+    - invitations
+    - invitations!
+    - event_types
+    - event_types!
+    - scheduled_events
+    - scheduled_events!
+    - webhooks
+    - webhooks!
+  - OrganizationMembership
+    - user_scope_webhooks
+    - user_scope_webhooks!
+  - User
+    - event_types
+    - scheduled_events
+    - webhooks
+    - webhooks!
+
 ## 0.7.0
 
 - supported a signing key parameter when creating webhooks. (#33)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This library supports a configurable logger.
 ```ruby
 # if the log level set :debug, you can get the request/response information.
 Calendly.configuration.logger.level = :debug
-invitation = my_org.create_invitation('foobar@example.com')
+invitation = org.create_invitation('foobar@example.com')
 # D, [2020-08-10T10:48:15] DEBUG -- : Request POST https://api.calendly.com/organizations/ORG001/invitations params:, body:{:email=>"foobar@example.com"}
 # D, [2020-08-10T10:48:16] DEBUG -- : Response status:201, body:{"resource":{"created_at":"2020-08-10T10:48:16.051159Z","email":"foobar@example.com","last_sent_at":"2020-08-10T10:48:16.096518Z","organization":"https://api.calendly.com/organizations/ORG001","status":"pending","updated_at":"2020-08-10T10:48:16.051159Z","uri":"https://api.calendly.com/organizations/ORG001/invitations/INV001"}}
 ```

--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -106,22 +106,22 @@ module Calendly
     # Returns all Event Types associated with a specified organization.
     #
     # @param [String] org_uri the specified organization (organization's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Array<Calendly::EventType>, Hash>]
     #  - [Array<Calendly::EventType>] event_types
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the org_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.6.0
-    def event_types(org_uri, opts = {})
+    def event_types(org_uri, options: nil)
       check_not_empty org_uri, 'org_uri'
 
       opts_keys = %i[count page_token sort]
       params = {organization: org_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'event_types', params: params
 
       items = body[:collection] || []
@@ -133,22 +133,22 @@ module Calendly
     # Returns all Event Types associated with a specified user.
     #
     # @param [String] user_uri the specified user (user's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Array<Calendly::EventType>, Hash>]
     #  - [Array<Calendly::EventType>] event_types
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the user_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.2
-    def event_types_by_user(user_uri, opts = {})
+    def event_types_by_user(user_uri, options: nil)
       check_not_empty user_uri, 'user_uri'
 
       opts_keys = %i[count page_token sort]
       params = {user: user_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'event_types', params: params
 
       items = body[:collection] || []
@@ -174,26 +174,26 @@ module Calendly
     # Get List of scheduled events belonging to a specific organization.
     #
     # @param [String] org_uri the specified organization (organization's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email.
-    # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Whether the scheduled event is active or canceled.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :invitee_email Return events scheduled with the specified invitee email.
+    # @option options [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option options [String] :status Whether the scheduled event is active or canceled.
     # @return [Array<Array<Calendly::Event>, Hash>]
     #  - [Array<Calendly::Event>] events
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the org_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.5.0
-    def scheduled_events(org_uri, opts = {})
+    def scheduled_events(org_uri, options: nil)
       check_not_empty org_uri, 'org_uri'
 
       opts_keys = %i[count invitee_email max_start_time min_start_time page_token sort status]
       params = {organization: org_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'scheduled_events', params: params
 
       items = body[:collection] || []
@@ -205,27 +205,27 @@ module Calendly
     # Get List of scheduled events belonging to a specific user.
     #
     # @param [String] user_uri the specified user (user's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [String] :organization the specified organization (organization's uri).
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email.
-    # @option opts [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Whether the scheduled event is active or canceled.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [String] :organization the specified organization (organization's uri).
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :invitee_email Return events scheduled with the specified invitee email.
+    # @option options [String] :max_start_time Upper bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option options [String] :status Whether the scheduled event is active or canceled.
     # @return [Array<Array<Calendly::Event>, Hash>]
     #  - [Array<Calendly::Event>] events
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the user_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.3
-    def scheduled_events_by_user(user_uri, opts = {})
+    def scheduled_events_by_user(user_uri, options: nil)
       check_not_empty user_uri, 'user_uri'
 
       opts_keys = %i[organization count invitee_email max_start_time min_start_time page_token sort status]
       params = {user: user_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'scheduled_events', params: params
 
       items = body[:collection] || []
@@ -255,23 +255,23 @@ module Calendly
     # Get List of Event Invitees.
     #
     # @param [String] uuid the specified event (event's uuid).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Whether the scheduled event is active or canceled.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option options [String] :status Whether the scheduled event is active or canceled.
     # @return [Array<Array<Calendly::Invitee>, Hash>]
     #  - [Array<Calendly::Invitee>] invitees
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.4
-    def event_invitees(uuid, opts = {})
+    def event_invitees(uuid, options: nil)
       check_not_empty uuid, 'uuid'
 
       opts_keys = %i[count email page_token sort status]
-      params = merge_options opts, opts_keys
+      params = merge_options options, opts_keys
       body = request :get, "scheduled_events/#{uuid}/invitees", params: params
 
       items = body[:collection] || []
@@ -297,22 +297,22 @@ module Calendly
     # Get List of memberships belonging to specific an organization.
     #
     # @param [String] org_uri the specified organization (organization's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
     # @return [Array<Array<Calendly::OrganizationMembership>, Hash>]
     #  - [Array<Calendly::OrganizationMembership>] memberships
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the org_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.5
-    def memberships(org_uri, opts = {})
+    def memberships(org_uri, options: nil)
       check_not_empty org_uri, 'org_uri'
 
       opts_keys = %i[count email page_token]
       params = {organization: org_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'organization_memberships', params: params
 
       items = body[:collection] || []
@@ -324,22 +324,22 @@ module Calendly
     # Get List of memberships belonging to specific a user.
     #
     # @param [String] user_uri the specified user (user's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
     # @return [Array<Array<Calendly::OrganizationMembership>, Hash>]
     #  - [Array<Calendly::OrganizationMembership>] memberships
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the user_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.5
-    def memberships_by_user(user_uri, opts = {})
+    def memberships_by_user(user_uri, options: nil)
       check_not_empty user_uri, 'user_uri'
 
       opts_keys = %i[count email page_token]
       params = {user: user_uri}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'organization_memberships', params: params
 
       items = body[:collection] || []
@@ -383,23 +383,23 @@ module Calendly
     # Get Organization Invitations.
     #
     # @param [String] uuid the specified organization (organization's uuid).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Filter by status.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @option options [String] :status Filter by status.
     # @return [<Array<Array<Calendly::OrganizationInvitation>, Hash>]
     #  - [Array<Calendly::OrganizationInvitation>] organizations
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.6
-    def invitations(uuid, opts = {})
+    def invitations(uuid, options: nil)
       check_not_empty uuid, 'uuid'
 
       opts_keys = %i[count email page_token sort status]
-      params = merge_options opts, opts_keys
+      params = merge_options options, opts_keys
 
       body = request :get, "organizations/#{uuid}/invitations", params: params
       items = body[:collection] || []
@@ -463,22 +463,22 @@ module Calendly
     # Get List of organization scope Webhooks.
     #
     # @param [String] org_uri the specified organization (organization's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Array<Calendly::WebhookSubscription>, Hash>]
     #  - [Array<Calendly::WebhookSubscription>] webhooks
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
     # @raise [Calendly::Error] if the org_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def webhooks(org_uri, opts = {})
+    def webhooks(org_uri, options: nil)
       check_not_empty org_uri, 'org_uri'
 
       opts_keys = %i[count page_token sort]
       params = {organization: org_uri, scope: 'organization'}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'webhook_subscriptions', params: params
       items = body[:collection] || []
       evs = items.map { |item| WebhookSubscription.new item, self }
@@ -490,10 +490,10 @@ module Calendly
     #
     # @param [String] org_uri the specified organization (organization's uri).
     # @param [String] user_uri the specified user (user's uri).
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Array<Calendly::WebhookSubscription>, Hash>]
     #  - [Array<Calendly::WebhookSubscription>] webhooks
     #  - [Hash] next_params the parameters to get next data. if thre is no next it returns nil.
@@ -501,13 +501,13 @@ module Calendly
     # @raise [Calendly::Error] if the user_uri arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def user_scope_webhooks(org_uri, user_uri, opts = {})
+    def user_scope_webhooks(org_uri, user_uri, options: nil)
       check_not_empty org_uri, 'org_uri'
       check_not_empty user_uri, 'user_uri'
 
       opts_keys = %i[count page_token sort]
       params = {organization: org_uri, user: user_uri, scope: 'user'}
-      params = merge_options opts, opts_keys, params
+      params = merge_options options, opts_keys, params
       body = request :get, 'webhook_subscriptions', params: params
       items = body[:collection] || []
       evs = items.map { |item| WebhookSubscription.new item, self }
@@ -565,7 +565,7 @@ module Calendly
     #
     # @param [String] uri A link to the resource that owns this scheduling Link.
     # @param [String] max_event_count The max number of events that can be scheduled using this scheduling link.
-    # @param [String] resource_type Resource type.
+    # @param [String] owner_type Resource type.
     # @return [Hash]
     # e.g.
     # {
@@ -575,17 +575,17 @@ module Calendly
     # }
     # @raise [Calendly::Error] if the uri arg is empty.
     # @raise [Calendly::Error] if the max_event_count arg is empty.
-    # @raise [Calendly::Error] if the resource_type arg is empty.
+    # @raise [Calendly::Error] if the owner_type arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.5.2
-    def create_schedule_link(uri, max_event_count = 1, resource_type: 'EventType')
+    def create_schedule_link(uri, max_event_count: 1, owner_type: 'EventType')
       check_not_empty uri, 'uri'
       check_not_empty max_event_count, 'max_event_count'
-      check_not_empty resource_type, 'resource_type'
+      check_not_empty owner_type, 'owner_type'
       params = {
         max_event_count: max_event_count,
         owner: uri,
-        owner_type: resource_type
+        owner_type: owner_type
       }
       body = request :post, 'scheduling_links', body: params
       body[:resource]

--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -87,10 +87,10 @@ module Calendly
     #
     # Returns all Event Invitees associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token
     # Pass this to get the next portion of collection.
     # @option opts [String] :sort Order results by the specified field and directin.
     # Accepts comma-separated list of {field}:{direction} values.
@@ -99,17 +99,17 @@ module Calendly
     # @raise [Calendly::Error] if the uuid is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
-    def invitees(opts = {})
+    def invitees(options: nil)
       return @cached_invitees if defined?(@cached_invitees) && @cached_invitees
 
-      request_proc = proc { |options| client.event_invitees uuid, options }
-      @cached_invitees = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.event_invitees uuid, options: opts }
+      @cached_invitees = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def invitees!(opts = {})
+    def invitees!(options: nil)
       @cached_invitees = nil
-      invitees opts
+      invitees options: options
     end
 
   private

--- a/lib/calendly/models/event_type.rb
+++ b/lib/calendly/models/event_type.rb
@@ -132,8 +132,8 @@ module Calendly
     # @raise [Calendly::Error] if the max_event_count arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.5.2
-    def create_schedule_link(max_event_count = 1)
-      client.create_schedule_link uri, max_event_count, resource_type: 'EventType'
+    def create_schedule_link(max_event_count: 1)
+      client.create_schedule_link uri, max_event_count: max_event_count, owner_type: 'EventType'
     end
 
   private

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -20,52 +20,52 @@ module Calendly
     #
     # Get List memberships of all users belonging to self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
     # @return [Array<Calendly::OrganizationMembership>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
-    def memberships(opts = {})
+    def memberships(options: nil)
       return @cached_memberships if defined?(@cached_memberships) && @cached_memberships
 
-      request_proc = proc { |options| client.memberships uri, options }
-      @cached_memberships = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.memberships uri, options: opts }
+      @cached_memberships = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def memberships!(opts = {})
+    def memberships!(options: nil)
       @cached_memberships = nil
-      memberships opts
+      memberships options: options
     end
 
     #
     # Get Organization Invitations.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :email Filter by email.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :email Filter by email.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin.
     # Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Filter by status.
+    # @option options [String] :status Filter by status.
     # @return [Array<Calendly::OrganizationInvitation>]
     # @raise [Calendly::Error] if the uuid is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
-    def invitations(opts = {})
+    def invitations(options: nil)
       return @cached_invitations if defined?(@cached_invitations) && @cached_invitations
 
-      request_proc = proc { |options| client.invitations uuid, options }
-      @cached_invitations = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.invitations uuid, options: opts }
+      @cached_invitations = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def invitations!(opts = {})
+    def invitations!(options: nil)
       @cached_invitations = nil
-      invitations opts
+      invitations options: options
     end
 
     #
@@ -84,80 +84,80 @@ module Calendly
     #
     # Returns all Event Types associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and direction.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and direction.
     # Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Calendly::EventType>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.6.0
-    def event_types(opts = {})
+    def event_types(options: nil)
       return @cached_event_types if defined?(@cached_event_types) && @cached_event_types
 
-      request_proc = proc { |options| client.event_types uri, options }
-      @cached_event_types = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.event_types uri, options: opts }
+      @cached_event_types = auto_pagination request_proc, options
     end
 
     # @since 0.6.0
-    def event_types!(opts = {})
+    def event_types!(options: nil)
       @cached_event_types = nil
-      event_types opts
+      event_types options: options
     end
 
     #
     # Returns all Scheduled Events associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email
-    # @option opts [String] :max_start_timeUpper bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :invitee_email Return events scheduled with the specified invitee email
+    # @option options [String] :max_start_timeUpper bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin.
     # Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Whether the scheduled event is active or canceled
+    # @option options [String] :status Whether the scheduled event is active or canceled
     # @return [Array<Calendly::Event>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.5.0
-    def scheduled_events(opts = {})
+    def scheduled_events(options: nil)
       return @cached_scheduled_events if defined?(@cached_scheduled_events) && @cached_scheduled_events
 
-      request_proc = proc { |options| client.scheduled_events uri, options }
-      @cached_scheduled_events = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.scheduled_events uri, options: opts }
+      @cached_scheduled_events = auto_pagination request_proc, options
     end
 
     # @since 0.5.0
-    def scheduled_events!(opts = {})
+    def scheduled_events!(options: nil)
       @cached_scheduled_events = nil
-      scheduled_events opts
+      scheduled_events options: options
     end
 
     #
     # Get List of organization scope Webhooks associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Calendly::WebhookSubscription>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def webhooks(opts = {})
+    def webhooks(options: nil)
       return @cached_webhooks if defined?(@cached_webhooks) && @cached_webhooks
 
-      request_proc = proc { |options| client.webhooks uri, options }
-      @cached_webhooks = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.webhooks uri, options: opts }
+      @cached_webhooks = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def webhooks!(opts = {})
+    def webhooks!(options: nil)
       @cached_webhooks = nil
-      webhooks opts
+      webhooks options: options
     end
 
     #

--- a/lib/calendly/models/organization_membership.rb
+++ b/lib/calendly/models/organization_membership.rb
@@ -65,23 +65,23 @@ module Calendly
     #
     # Get List of user scope Webhooks associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Calendly::WebhookSubscription>]
     # @raise [Calendly::Error] if the organization.uri is empty.
     # @raise [Calendly::Error] if the user.uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def user_scope_webhooks(opts = {})
-      user.webhooks(opts)
+    def user_scope_webhooks(options: nil)
+      user.webhooks options: options
     end
 
     # @since 0.2.0
-    def user_scope_webhooks!(opts = {})
-      user.webhooks!(opts)
+    def user_scope_webhooks!(options: nil)
+      user.webhooks! options: options
     end
 
     #

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -91,82 +91,82 @@ module Calendly
     #
     # Returns all Event Types associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and direction.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and direction.
     # Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Calendly::EventType>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
-    def event_types(opts = {})
+    def event_types(options: nil)
       return @cached_event_types if defined?(@cached_event_types) && @cached_event_types
 
-      request_proc = proc { |options| client.event_types_by_user uri, options }
-      @cached_event_types = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.event_types_by_user uri, options: opts }
+      @cached_event_types = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def event_types!(opts = {})
+    def event_types!(options: nil)
       @cached_event_types = nil
-      event_types opts
+      event_types options: options
     end
 
     #
     # Returns all Scheduled Events associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :invitee_email Return events scheduled with the specified invitee email
-    # @option opts [String] :max_start_timeUpper bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :invitee_email Return events scheduled with the specified invitee email
+    # @option options [String] :max_start_timeUpper bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :min_start_time Lower bound (inclusive) for an event's start time to filter by.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin.
     # Accepts comma-separated list of {field}:{direction} values.
-    # @option opts [String] :status Whether the scheduled event is active or canceled
+    # @option options [String] :status Whether the scheduled event is active or canceled
     # @return [Array<Calendly::Event>]
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.0
-    def scheduled_events(opts = {})
+    def scheduled_events(options: nil)
       return @cached_scheduled_events if defined?(@cached_scheduled_events) && @cached_scheduled_events
 
-      request_proc = proc { |options| client.scheduled_events_by_user uri, options }
-      @cached_scheduled_events = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.scheduled_events_by_user uri, options: opts }
+      @cached_scheduled_events = auto_pagination request_proc, options
     end
 
     # @since 0.2.0
-    def scheduled_events!(opts = {})
+    def scheduled_events!(options: nil)
       @cached_scheduled_events = nil
-      scheduled_events opts
+      scheduled_events options: options
     end
 
     #
     # Get List of user scope Webhooks associated with self.
     #
-    # @param [Hash] opts the optional request parameters.
-    # @option opts [Integer] :count Number of rows to return.
-    # @option opts [String] :page_token Pass this to get the next portion of collection.
-    # @option opts [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
+    # @param [Hash] options the optional request parameters. Optional.
+    # @option options [Integer] :count Number of rows to return.
+    # @option options [String] :page_token Pass this to get the next portion of collection.
+    # @option options [String] :sort Order results by the specified field and directin. Accepts comma-separated list of {field}:{direction} values.
     # Accepts comma-separated list of {field}:{direction} values.
     # @return [Array<Calendly::WebhookSubscription>]
     # @raise [Calendly::Error] if the organization.uri is empty.
     # @raise [Calendly::Error] if the uri is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.6.0
-    def webhooks(opts = {})
+    def webhooks(options: nil)
       return @cached_webhooks if defined?(@cached_webhooks) && @cached_webhooks
 
       org_uri = current_organization&.uri
-      request_proc = proc { |options| client.user_scope_webhooks org_uri, uri, options }
-      @cached_webhooks = auto_pagination request_proc, opts
+      request_proc = proc { |opts| client.user_scope_webhooks org_uri, uri, options: opts }
+      @cached_webhooks = auto_pagination request_proc, options
     end
 
     # @since 0.6.0
-    def webhooks!(opts = {})
+    def webhooks!(options: nil)
       @cached_webhooks = nil
-      webhooks opts
+      webhooks options: options
     end
 
     #

--- a/lib/calendly/version.rb
+++ b/lib/calendly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Calendly
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -191,10 +191,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      event_types_page1, next_params1 = @client.event_types org_uri, option_params1
+      event_types_page1, next_params1 = @client.event_types org_uri, options: option_params1
       org_uri_page1 = next_params1.delete :organization
       # request page2
-      event_types_page2, next_params2 = @client.event_types org_uri_page1, next_params1
+      event_types_page2, next_params2 = @client.event_types org_uri_page1, options: next_params1
 
       assert_equal 2, event_types_page1.length
       assert_equal 1, event_types_page2.length
@@ -247,10 +247,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      event_types_page1, next_params1 = @client.event_types_by_user user_uri, option_params1
+      event_types_page1, next_params1 = @client.event_types_by_user user_uri, options: option_params1
       user_uri_page1 = next_params1.delete :user
       # request page2
-      event_types_page2, next_params2 = @client.event_types_by_user user_uri_page1, next_params1
+      event_types_page2, next_params2 = @client.event_types_by_user user_uri_page1, options: next_params1
 
       assert_equal 2, event_types_page1.length
       assert_equal 1, event_types_page2.length
@@ -333,10 +333,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      evs_page1, next_params1 = @client.scheduled_events org_uri, params1
+      evs_page1, next_params1 = @client.scheduled_events org_uri, options: params1
       # org_uri = next_params1.delete :organization
       # request page2
-      evs_page2, next_params2 = @client.scheduled_events org_uri, next_params1
+      evs_page2, next_params2 = @client.scheduled_events org_uri, options: next_params1
 
       assert_equal 2, evs_page1.length
       assert_equal 1, evs_page2.length
@@ -397,10 +397,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      evs_page1, next_params1 = @client.scheduled_events_by_user user_uri, params1
+      evs_page1, next_params1 = @client.scheduled_events_by_user user_uri, options: params1
       user_uri = next_params1.delete :user
       # request page2
-      evs_page2, next_params2 = @client.scheduled_events_by_user user_uri, next_params1
+      evs_page2, next_params2 = @client.scheduled_events_by_user user_uri, options: next_params1
 
       assert_equal 2, evs_page1.length
       assert_equal 1, evs_page2.length
@@ -484,9 +484,9 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      invs_page1, next_params1 = @client.event_invitees ev_uuid, params1
+      invs_page1, next_params1 = @client.event_invitees ev_uuid, options: params1
       # request page2
-      invs_page2, next_params2 = @client.event_invitees ev_uuid, next_params1
+      invs_page2, next_params2 = @client.event_invitees ev_uuid, options: next_params1
 
       assert_equal 2, invs_page1.length
       assert_equal 1, invs_page2.length
@@ -548,10 +548,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      mems_page1, next_params1 = @client.memberships org_uri, params1
+      mems_page1, next_params1 = @client.memberships org_uri, options: params1
       org_uri = next_params1.delete(:organization)
       # request page2
-      mems_page2, next_params2 = @client.memberships org_uri, next_params1
+      mems_page2, next_params2 = @client.memberships org_uri, options: next_params1
 
       assert_equal 2, mems_page1.length
       assert_equal 1, mems_page2.length
@@ -674,9 +674,9 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      invs_page1, next_params1 = @client.invitations org_uuid, params1
+      invs_page1, next_params1 = @client.invitations org_uuid, options: params1
       # request page2
-      invs_page2, next_params2 = @client.invitations org_uuid, next_params1
+      invs_page2, next_params2 = @client.invitations org_uuid, options: next_params1
 
       assert_equal 2, invs_page1.length
       assert_equal 1, invs_page2.length
@@ -807,10 +807,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      webhooks1, next_params1 = @client.webhooks org_uri, params1
+      webhooks1, next_params1 = @client.webhooks org_uri, options: params1
       org_uri = next_params1.delete :organization
       # request page2
-      webhooks2, next_params2 = @client.webhooks org_uri, next_params1
+      webhooks2, next_params2 = @client.webhooks org_uri, options: next_params1
 
       assert_equal 2, webhooks1.length
       assert_equal 1, webhooks2.length
@@ -872,10 +872,10 @@ module Calendly
       add_stub_request :get, url2, res_body: res_body2
 
       # request page1
-      webhooks1, next_params1 = @client.user_scope_webhooks org_uri, user_uri, params1
+      webhooks1, next_params1 = @client.user_scope_webhooks org_uri, user_uri, options: params1
       org_uri = next_params1.delete :organization
       # request page2
-      webhooks2, next_params2 = @client.user_scope_webhooks org_uri, user_uri, next_params1
+      webhooks2, next_params2 = @client.user_scope_webhooks org_uri, user_uri, options: next_params1
 
       assert_equal 2, webhooks1.length
       assert_equal 1, webhooks2.length
@@ -1049,16 +1049,16 @@ user: user_uri, signing_key: signing_key}
     def test_that_it_creates_schedule_link
       max_event_count = 1
       resource_uri = "#{HOST}/resource/0001"
-      resource_type = 'FooBar'
+      owner_type = 'FooBar'
       req_body = {
         max_event_count: max_event_count,
         owner: resource_uri,
-        owner_type: resource_type
+        owner_type: owner_type
       }
       res_body = load_test_data 'schedule_link_001.json'
       url = "#{HOST}/scheduling_links"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
-      assert_schedule_link_001 @client.create_schedule_link(resource_uri, resource_type: resource_type)
+      assert_schedule_link_001 @client.create_schedule_link(resource_uri, owner_type: owner_type)
     end
 
     def test_that_it_raises_an_argument_error_on_create_schedule_link
@@ -1068,14 +1068,14 @@ user: user_uri, signing_key: signing_key}
       assert_required_error proc_uri_arg_is_empty, 'uri'
 
       proc_max_event_count_arg_is_empty = proc do
-        @client.create_schedule_link 'uri', nil
+        @client.create_schedule_link 'uri', max_event_count: nil
       end
       assert_required_error proc_max_event_count_arg_is_empty, 'max_event_count'
 
-      proc_resource_type_arg_is_empty = proc do
-        @client.create_schedule_link 'uri', resource_type: nil
+      proc_owner_type_arg_is_empty = proc do
+        @client.create_schedule_link 'uri', owner_type: nil
       end
-      assert_required_error proc_resource_type_arg_is_empty, 'resource_type'
+      assert_required_error proc_owner_type_arg_is_empty, 'owner_type'
     end
 
   private

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -75,7 +75,7 @@ module Calendly
       url2 = "#{HOST}/scheduled_events/#{ev.uuid}/invitees?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      invs = ev.invitees params1
+      invs = ev.invitees options: params1
       assert_equal 3, invs.length
       assert_event201_invitee003 invs[0]
       assert_event201_invitee002 invs[1]

--- a/test/models/event_type_test.rb
+++ b/test/models/event_type_test.rb
@@ -40,7 +40,7 @@ module Calendly
       res_body = load_test_data 'schedule_link_001.json'
       url = "#{HOST}/scheduling_links"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
-      assert_schedule_link_001 @event_type.create_schedule_link(3)
+      assert_schedule_link_001 @event_type.create_schedule_link(max_event_count: 3)
     end
   end
 end

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -86,7 +86,7 @@ module Calendly
       url2 = "#{HOST}/webhook_subscriptions?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      webhooks = @mem.user_scope_webhooks params1
+      webhooks = @mem.user_scope_webhooks options: params1
       assert_equal 3, webhooks.length
       assert_user_webhook_003 webhooks[0]
       assert_user_webhook_002 webhooks[1]

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -58,7 +58,7 @@ module Calendly
       url2 = "#{HOST}/organization_memberships?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      mems = @org.memberships params1
+      mems = @org.memberships options: params1
       assert_equal 3, mems.length
       assert_org_mem001 mems[0]
       assert_org_mem002 mems[1]
@@ -100,7 +100,7 @@ module Calendly
       url2 = "#{@org_uri}/invitations?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      invs = @org.invitations params1
+      invs = @org.invitations options: params1
       assert_equal 3, invs.length
       assert_org_inv003 invs[0]
       assert_org_inv002 invs[1]
@@ -160,7 +160,7 @@ module Calendly
       url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      evs = @org.scheduled_events params1
+      evs = @org.scheduled_events options: params1
       assert_equal 3, evs.length
       assert_event013 evs[0]
       assert_event012 evs[1]
@@ -199,7 +199,7 @@ module Calendly
       res_body2 = load_test_data 'event_types_002_page2.json'
       add_stub_request :get, url2, res_body: res_body2
 
-      event_types = @org.event_types params1
+      event_types = @org.event_types options: params1
       assert_equal 3, event_types.length
       assert_event_type003 event_types[0]
       assert_event_type002 event_types[1]
@@ -251,7 +251,7 @@ module Calendly
       url2 = "#{HOST}/webhook_subscriptions?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      webhooks = @org.webhooks params1
+      webhooks = @org.webhooks options: params1
       assert_equal 3, webhooks.length
       assert_org_webhook_003 webhooks[0]
       assert_org_webhook_002 webhooks[1]

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -80,7 +80,7 @@ module Calendly
       res_body2 = load_test_data 'event_types_002_page2.json'
       add_stub_request :get, url2, res_body: res_body2
 
-      event_types = @user.event_types params1
+      event_types = @user.event_types options: params1
       assert_equal 3, event_types.length
       assert_event_type003 event_types[0]
       assert_event_type002 event_types[1]
@@ -129,7 +129,7 @@ module Calendly
       url2 = "#{HOST}/scheduled_events?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      evs = @user.scheduled_events params1
+      evs = @user.scheduled_events options: params1
       assert_equal 3, evs.length
       assert_event013 evs[0]
       assert_event012 evs[1]
@@ -183,7 +183,7 @@ module Calendly
       url2 = "#{HOST}/webhook_subscriptions?#{URI.encode_www_form(params2)}"
       add_stub_request :get, url2, res_body: res_body2
 
-      webhooks = @user.webhooks params1
+      webhooks = @user.webhooks options: params1
       assert_equal 3, webhooks.length
       assert_user_webhook_003 webhooks[0]
       assert_user_webhook_002 webhooks[1]


### PR DESCRIPTION
Use keyword arguments for optional parameters, to be friendly for programmers.