### PR TITLE
add signing key to webhook model

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ org = client.me.current_organization
 org_webhook = org.create_webhook(url, events)
 # => #<Calendly::WebhookSubscription uuid="ORG_WEBHOOK_001", state="active", scope="organization", events=["invitee.created", "invitee.canceled"], callback_url="https://example.com/received_event", ..>
 
+#
+# create an organization scope webhook with a signing_key.
+#
+secret = SecureRandom.uuid
+org_webhook = org.create_webhook(url, events, signing_key: secret)
+# => #<Calendly::WebhookSubscription uuid="ORG_WEBHOOK_001", state="active", scope="organization", events=["invitee.created", "invitee.canceled"], callback_url="https://example.com/received_event", signing_key="10093ca7-aef1-4455-9024-8f68eaf0558f"..>
+
+
 # list of organization scope webhooks
 org.webhooks
 # => [#<Calendly::WebhookSubscription uuid="ORG_WEBHOOK_001", state="active", scope="organization", events=["invitee.created", "invitee.canceled"], callback_url="https://example.com/received_event", ..>]

--- a/lib/calendly/models/webhook_subscription.rb
+++ b/lib/calendly/models/webhook_subscription.rb
@@ -49,6 +49,10 @@ module Calendly
     # The scope of the webhook subscription.
     attr_accessor :scope
 
+    # @return [String]
+    # Secret key shared between your application and Calendly. Optional.
+    attr_accessor :signing_key
+
     # @return [Calendly::Organization]
     # The organization that's associated with the webhook subscription.
     attr_accessor :organization

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -880,6 +880,7 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
+    assert_equal '03517b0f-f0f7-4b2c-ba8a-46cf95b85887', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'organization', webhook.scope
@@ -931,6 +932,7 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
+    assert_equal '10093ca7-aef1-4455-9024-8f68eaf0558f', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'user', webhook.scope

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -931,7 +931,7 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
-    assert_equal '03517b0f-f0f7-4b2c-ba8a-46cf95b85887', webhook.signing_key
+    assert_equal 'secret_string', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'organization', webhook.scope
@@ -1004,7 +1004,7 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
-    assert_equal '10093ca7-aef1-4455-9024-8f68eaf0558f', webhook.signing_key
+    assert_equal 'secret_string', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'user', webhook.scope

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -880,7 +880,6 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
-    assert_equal '03517b0f-f0f7-4b2c-ba8a-46cf95b85887', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'organization', webhook.scope
@@ -925,6 +924,25 @@ module AssertHelper
     assert_equal 'https://api.calendly.com/users/U001', webhook.creator.uri
   end
 
+  def assert_org_webhook_004(webhook)
+    assert webhook.client.is_a? Calendly::Client
+    assert_equal 'https://api.calendly.com/webhook_subscriptions/ORG_WEBHOOK001', webhook.uri
+    assert_equal 'https://example.com/organization/webhook001', webhook.callback_url
+    assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
+    assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
+    assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
+    assert_equal '03517b0f-f0f7-4b2c-ba8a-46cf95b85887', webhook.signing_key
+    assert_equal 'active', webhook.state
+    assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
+    assert_equal 'organization', webhook.scope
+    assert_equal 'ORG001', webhook.organization.uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', webhook.organization.uri
+    assert_nil webhook.user
+    assert_equal 'U001', webhook.creator.uuid
+    assert_equal 'https://api.calendly.com/users/U001', webhook.creator.uri
+  end
+
+
   def assert_user_webhook_001(webhook)
     assert webhook.client.is_a? Calendly::Client
     assert_equal 'https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001', webhook.uri
@@ -932,7 +950,6 @@ module AssertHelper
     assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
     assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
     assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
-    assert_equal '10093ca7-aef1-4455-9024-8f68eaf0558f', webhook.signing_key
     assert_equal 'active', webhook.state
     assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'user', webhook.scope
@@ -971,6 +988,25 @@ module AssertHelper
     assert_nil webhook.retry_started_at
     assert_equal 'active', webhook.state
     assert_equal ['invitee.canceled'], webhook.events
+    assert_equal 'user', webhook.scope
+    assert_equal 'ORG001', webhook.organization.uuid
+    assert_equal 'https://api.calendly.com/organizations/ORG001', webhook.organization.uri
+    assert_equal 'U001', webhook.user.uuid
+    assert_equal 'https://api.calendly.com/users/U001', webhook.user.uri
+    assert_equal 'U001', webhook.creator.uuid
+    assert_equal 'https://api.calendly.com/users/U001', webhook.creator.uri
+  end
+
+  def assert_user_webhook_004(webhook)
+    assert webhook.client.is_a? Calendly::Client
+    assert_equal 'https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001', webhook.uri
+    assert_equal 'https://example.com/user/webhook001', webhook.callback_url
+    assert_equal Time.parse('2020-09-17T02:00:00.000000Z'), webhook.created_at
+    assert_equal Time.parse('2020-09-17T03:00:00.000000Z'), webhook.updated_at
+    assert_equal Time.parse('2020-09-17T04:00:00.000000Z'), webhook.retry_started_at
+    assert_equal '10093ca7-aef1-4455-9024-8f68eaf0558f', webhook.signing_key
+    assert_equal 'active', webhook.state
+    assert_equal ['invitee.created', 'invitee.canceled'], webhook.events
     assert_equal 'user', webhook.scope
     assert_equal 'ORG001', webhook.organization.uuid
     assert_equal 'https://api.calendly.com/organizations/ORG001', webhook.organization.uri

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -929,7 +929,7 @@ signing_key: signing_key}
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
       webhook = @client.create_webhook webhook_url, events, org_uri, signing_key: signing_key
-      assert_org_webhook_001 webhook
+      assert_org_webhook_004 webhook
     end
 
     def test_that_it_creates_user_scope_webhook
@@ -944,7 +944,7 @@ signing_key: signing_key}
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
       webhook = @client.create_webhook webhook_url, events, org_uri, user_uri: user_uri
-      assert_user_webhook_001 webhook
+      assert_user_webhook_004 webhook
     end
 
     def test_that_it_creates_user_scope_webhook_with_signing_key
@@ -961,7 +961,7 @@ user: user_uri, signing_key: signing_key}
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
       webhook = @client.create_webhook webhook_url, events, org_uri, user_uri: user_uri, signing_key: signing_key
-      assert_user_webhook_001 webhook
+      assert_user_webhook_004 webhook
     end
 
     def test_that_it_raises_an_argument_error_on_create_webhook

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -923,7 +923,7 @@ module Calendly
       signing_key = 'secret_string'
       req_body = {url: webhook_url, events: events, organization: org_uri, scope: 'organization',
 signing_key: signing_key}
-      res_body = load_test_data 'webhook_organization_001.json'
+      res_body = load_test_data 'webhook_organization_004.json'
 
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
@@ -944,7 +944,7 @@ signing_key: signing_key}
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
       webhook = @client.create_webhook webhook_url, events, org_uri, user_uri: user_uri
-      assert_user_webhook_004 webhook
+      assert_user_webhook_001 webhook
     end
 
     def test_that_it_creates_user_scope_webhook_with_signing_key
@@ -955,7 +955,7 @@ signing_key: signing_key}
       signing_key = 'secret_string'
       req_body = {url: webhook_url, events: events, organization: org_uri, scope: 'user',
 user: user_uri, signing_key: signing_key}
-      res_body = load_test_data 'webhook_user_001.json'
+      res_body = load_test_data 'webhook_user_004.json'
 
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -116,7 +116,7 @@ signing_key: signing_key}
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
-      assert_user_webhook_001 @mem.create_user_scope_webhook webhook_url, events, signing_key: signing_key
+      assert_user_webhook_004 @mem.create_user_scope_webhook webhook_url, events, signing_key: signing_key
     end
   end
 end

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -111,7 +111,7 @@ module Calendly
       signing_key = 'secret_string'
       req_body = {url: webhook_url, events: events, organization: @org_uri, scope: 'user', user: @user_uri,
 signing_key: signing_key}
-      res_body = load_test_data 'webhook_user_001.json'
+      res_body = load_test_data 'webhook_user_004.json'
 
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -276,7 +276,7 @@ module Calendly
       signing_key = 'secret_string'
       req_body = {url: webhook_url, events: events, organization: @org_uri, scope: 'organization',
 signing_key: signing_key}
-      res_body = load_test_data 'webhook_organization_001.json'
+      res_body = load_test_data 'webhook_organization_004.json'
 
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -281,7 +281,7 @@ signing_key: signing_key}
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
-      assert_org_webhook_001 @org.create_webhook webhook_url, events, signing_key: signing_key
+      assert_org_webhook_004 @org.create_webhook webhook_url, events, signing_key: signing_key
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -208,12 +208,12 @@ module Calendly
       signing_key = 'secret_string'
       req_body = {url: webhook_url, events: events, organization: @org_uri, scope: 'user', user: @user_uri,
 signing_key: signing_key}
-      res_body = load_test_data 'webhook_user_001.json'
+      res_body = load_test_data 'webhook_user_004.json'
 
       url = "#{HOST}/webhook_subscriptions"
       add_stub_request :post, url, req_body: req_body, res_body: res_body, res_status: 201
 
-      assert_user_webhook_001 @user.create_webhook webhook_url, events, signing_key: signing_key
+      assert_user_webhook_004 @user.create_webhook webhook_url, events, signing_key: signing_key
     end
   end
 end

--- a/test/testdata/webhook_organization_001.json
+++ b/test/testdata/webhook_organization_001.json
@@ -3,13 +3,17 @@
     "callback_url": "https://example.com/organization/webhook001",
     "created_at": "2020-09-17T02:00:00.000000Z",
     "creator": "https://api.calendly.com/users/U001",
-    "events": ["invitee.created", "invitee.canceled"],
+    "events": [
+      "invitee.created",
+      "invitee.canceled"
+    ],
     "organization": "https://api.calendly.com/organizations/ORG001",
     "retry_started_at": "2020-09-17T04:00:00.000000Z",
     "scope": "organization",
     "state": "active",
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/ORG_WEBHOOK001",
-    "user": null
+    "user": null,
+    "signing_key": "03517b0f-f0f7-4b2c-ba8a-46cf95b85887"
   }
 }

--- a/test/testdata/webhook_organization_004.json
+++ b/test/testdata/webhook_organization_004.json
@@ -14,6 +14,6 @@
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/ORG_WEBHOOK001",
     "user": null,
-    "signing_key": "03517b0f-f0f7-4b2c-ba8a-46cf95b85887"
+    "signing_key": "secret_string"
   }
 }

--- a/test/testdata/webhook_organization_004.json
+++ b/test/testdata/webhook_organization_004.json
@@ -13,6 +13,7 @@
     "state": "active",
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/ORG_WEBHOOK001",
-    "user": null
+    "user": null,
+    "signing_key": "03517b0f-f0f7-4b2c-ba8a-46cf95b85887"
   }
 }

--- a/test/testdata/webhook_user_001.json
+++ b/test/testdata/webhook_user_001.json
@@ -13,7 +13,6 @@
     "state": "active",
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001",
-    "user": "https://api.calendly.com/users/U001",
-    "signing_key": "10093ca7-aef1-4455-9024-8f68eaf0558f"
+    "user": "https://api.calendly.com/users/U001"
   }
 }

--- a/test/testdata/webhook_user_001.json
+++ b/test/testdata/webhook_user_001.json
@@ -3,13 +3,17 @@
     "callback_url": "https://example.com/user/webhook001",
     "created_at": "2020-09-17T02:00:00.000000Z",
     "creator": "https://api.calendly.com/users/U001",
-    "events": ["invitee.created", "invitee.canceled"],
+    "events": [
+      "invitee.created",
+      "invitee.canceled"
+    ],
     "organization": "https://api.calendly.com/organizations/ORG001",
     "retry_started_at": "2020-09-17T04:00:00.000000Z",
     "scope": "user",
     "state": "active",
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001",
-    "user": "https://api.calendly.com/users/U001"
+    "user": "https://api.calendly.com/users/U001",
+    "signing_key": "10093ca7-aef1-4455-9024-8f68eaf0558f"
   }
 }

--- a/test/testdata/webhook_user_004.json
+++ b/test/testdata/webhook_user_004.json
@@ -14,6 +14,6 @@
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001",
     "user": "https://api.calendly.com/users/U001",
-    "signing_key": "10093ca7-aef1-4455-9024-8f68eaf0558f"
+    "signing_key": "secret_string'"
   }
 }

--- a/test/testdata/webhook_user_004.json
+++ b/test/testdata/webhook_user_004.json
@@ -1,6 +1,6 @@
 {
   "resource": {
-    "callback_url": "https://example.com/organization/webhook001",
+    "callback_url": "https://example.com/user/webhook001",
     "created_at": "2020-09-17T02:00:00.000000Z",
     "creator": "https://api.calendly.com/users/U001",
     "events": [
@@ -9,10 +9,11 @@
     ],
     "organization": "https://api.calendly.com/organizations/ORG001",
     "retry_started_at": "2020-09-17T04:00:00.000000Z",
-    "scope": "organization",
+    "scope": "user",
     "state": "active",
     "updated_at": "2020-09-17T03:00:00.000000Z",
-    "uri": "https://api.calendly.com/webhook_subscriptions/ORG_WEBHOOK001",
-    "user": null
+    "uri": "https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001",
+    "user": "https://api.calendly.com/users/U001",
+    "signing_key": "10093ca7-aef1-4455-9024-8f68eaf0558f"
   }
 }

--- a/test/testdata/webhook_user_004.json
+++ b/test/testdata/webhook_user_004.json
@@ -14,6 +14,6 @@
     "updated_at": "2020-09-17T03:00:00.000000Z",
     "uri": "https://api.calendly.com/webhook_subscriptions/USER_WEBHOOK001",
     "user": "https://api.calendly.com/users/U001",
-    "signing_key": "secret_string'"
+    "signing_key": "secret_string"
   }
 }


### PR DESCRIPTION
In order for the application to verify the signing key, it needs to be available in the webhook model.
* Added the signing key
* updated test cases to assert key is available