### PR TITLE
Update regexes so that new UUID format can be identified

### DIFF
--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -12,7 +12,7 @@ module Calendly
   # A meeting that has been scheduled.
   class Event
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/(\S+)\z}.freeze
     TIME_FIELDS = %i[start_time end_time created_at updated_at].freeze
     ASSOCIATION = {
       event_type: EventType,

--- a/lib/calendly/models/event_type.rb
+++ b/lib/calendly/models/event_type.rb
@@ -10,7 +10,7 @@ module Calendly
   # A configuration for a schedulable event.
   class EventType
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/event_types/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/event_types/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
     ASSOCIATION = {profile: EventTypeProfile, custom_questions: EventTypeCustomQuestion}.freeze
 

--- a/lib/calendly/models/invitee.rb
+++ b/lib/calendly/models/invitee.rb
@@ -13,7 +13,7 @@ module Calendly
   # An individual who has been invited to meet with a Calendly member.
   class Invitee
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/\w+/invitees/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/scheduled_events/\S+/invitees/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
     ASSOCIATION = {
       event: Event,

--- a/lib/calendly/models/organization.rb
+++ b/lib/calendly/models/organization.rb
@@ -7,7 +7,7 @@ module Calendly
   # Calendly's organization model.
   class Organization
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/organizations/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/organizations/(\S+)\z}.freeze
 
     # @return [String]
     # unique id of the Organization object.

--- a/lib/calendly/models/organization_invitation.rb
+++ b/lib/calendly/models/organization_invitation.rb
@@ -9,7 +9,7 @@ module Calendly
   # Calendly's organization invitation model.
   class OrganizationInvitation
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/organizations/\w+/invitations/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/organizations/\w+/invitations/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at last_sent_at].freeze
     ASSOCIATION = {user: User, organization: Organization}.freeze
 

--- a/lib/calendly/models/organization_membership.rb
+++ b/lib/calendly/models/organization_membership.rb
@@ -9,7 +9,7 @@ module Calendly
   # Calendly's organization membership model.
   class OrganizationMembership
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/organization_memberships/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/organization_memberships/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
     ASSOCIATION = {user: User, organization: Organization}.freeze
 

--- a/lib/calendly/models/team.rb
+++ b/lib/calendly/models/team.rb
@@ -7,7 +7,7 @@ module Calendly
   # Calendly's team model.
   class Team
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/teams/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/teams/(\S+)\z}.freeze
 
     # @return [String]
     # unique id of the Team object.

--- a/lib/calendly/models/user.rb
+++ b/lib/calendly/models/user.rb
@@ -8,7 +8,7 @@ module Calendly
   # Primary account details of a specific user.
   class User
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/users/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/users/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at].freeze
     ASSOCIATION = {current_organization: Organization}.freeze
 

--- a/lib/calendly/models/webhook_subscription.rb
+++ b/lib/calendly/models/webhook_subscription.rb
@@ -9,7 +9,7 @@ module Calendly
   # Calendly's webhook model.
   class WebhookSubscription
     include ModelUtils
-    UUID_RE = %r{\A#{Client::API_HOST}/webhook_subscriptions/(\w+)\z}.freeze
+    UUID_RE = %r{\A#{Client::API_HOST}/webhook_subscriptions/(\S+)\z}.freeze
     TIME_FIELDS = %i[created_at updated_at retry_started_at].freeze
     ASSOCIATION = {organization: Organization, user: User, creator: User}.freeze
 


### PR DESCRIPTION
Calendly has updated their UUID format that uses "-" and so the regex that was used to identify the UUID was not working. I have updated the regex to be able to identify a UUID like "3d9c2990-e847-458d-95dc-e1cf6a7ec745".