### PR TITLE
Chore: Add user email to event memberships object

### DIFF
--- a/lib/calendly/models/event.rb
+++ b/lib/calendly/models/event.rb
@@ -128,11 +128,14 @@ module Calendly
 
     def after_set_attributes(attrs)
       super attrs
-      if event_memberships.is_a? Array # rubocop:disable Style/GuardClause
-        @event_memberships = event_memberships.map do |params|
-          uri = params[:user]
-          User.new({uri: uri}, @client)
-        end
+
+      return unless event_memberships.is_a? Array
+
+      @event_memberships = event_memberships.map do |params|
+        uri = params[:user]
+        email = params[:user_email]
+
+        User.new({uri: uri, email: email}, @client)
       end
     end
   end

--- a/test/assert_helper.rb
+++ b/test/assert_helper.rb
@@ -364,6 +364,7 @@ module AssertHelper
     assert user.is_a? Calendly::User
     assert_equal 'U001', user.id
     assert_equal 'https://api.calendly.com/users/U001', user.uri
+    assert_equal 'user_U001@email.com', user.email
 
     assert_equal 1, ev.event_guests.length
     guest = ev.event_guests[0]
@@ -398,6 +399,7 @@ module AssertHelper
     assert user.is_a? Calendly::User
     assert_equal 'U001', user.id
     assert_equal 'https://api.calendly.com/users/U001', user.uri
+    assert_equal 'user_U001@email.com', user.email
 
     assert_equal 2, ev.event_guests.length
     guest = ev.event_guests[0]
@@ -440,10 +442,12 @@ module AssertHelper
     assert user.is_a? Calendly::User
     assert_equal 'U001', user.id
     assert_equal 'https://api.calendly.com/users/U001', user.uri
+    assert_equal 'user_U001@email.com', user.email
     user = ev.event_memberships[1]
     assert user.is_a? Calendly::User
     assert_equal 'U101', user.id
     assert_equal 'https://api.calendly.com/users/U101', user.uri
+    assert_equal 'user_U101@email.com', user.email
 
     assert_equal [], ev.event_guests
   end
@@ -473,10 +477,12 @@ module AssertHelper
     assert user.is_a? Calendly::User
     assert_equal 'U001', user.id
     assert_equal 'https://api.calendly.com/users/U001', user.uri
+    assert_equal 'user_U001@email.com', user.email
     user = ev.event_memberships[1]
     assert user.is_a? Calendly::User
     assert_equal 'U102', user.id
     assert_equal 'https://api.calendly.com/users/U102', user.uri
+    assert_equal 'user_U102@email.com', user.email
 
     assert_equal [], ev.event_guests
   end
@@ -506,10 +512,12 @@ module AssertHelper
     assert user.is_a? Calendly::User
     assert_equal 'U001', user.id
     assert_equal 'https://api.calendly.com/users/U001', user.uri
+    assert_equal 'user_U001@email.com', user.email
     user = ev.event_memberships[1]
     assert user.is_a? Calendly::User
     assert_equal 'U103', user.id
     assert_equal 'https://api.calendly.com/users/U103', user.uri
+    assert_equal 'user_U103@email.com', user.email
 
     assert_equal [], ev.event_guests
   end

--- a/test/testdata/scheduled_event_001.json
+++ b/test/testdata/scheduled_event_001.json
@@ -16,7 +16,8 @@
     ],
     "event_memberships": [
       {
-        "user": "https://api.calendly.com/users/U001"
+        "user": "https://api.calendly.com/users/U001",
+        "user_email": "user_U001@email.com"
       }
     ],
     "event_type": "https://api.calendly.com/event_types/ET001",

--- a/test/testdata/scheduled_events_001.json
+++ b/test/testdata/scheduled_events_001.json
@@ -17,7 +17,8 @@
       ],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET001",
@@ -50,7 +51,8 @@
       ],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET002",

--- a/test/testdata/scheduled_events_002_page1.json
+++ b/test/testdata/scheduled_events_002_page1.json
@@ -6,10 +6,12 @@
       "event_guests": [],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         },
         {
-          "user": "https://api.calendly.com/users/U103"
+          "user": "https://api.calendly.com/users/U103",
+          "user_email": "user_U103@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET003",
@@ -35,10 +37,12 @@
       "event_guests": [],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         },
         {
-          "user": "https://api.calendly.com/users/U102"
+          "user": "https://api.calendly.com/users/U102",
+          "user_email": "user_U102@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET002",

--- a/test/testdata/scheduled_events_002_page1_user.json
+++ b/test/testdata/scheduled_events_002_page1_user.json
@@ -6,10 +6,12 @@
       "event_guests": [],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         },
         {
-          "user": "https://api.calendly.com/users/U103"
+          "user": "https://api.calendly.com/users/U103",
+          "user_email": "user_U103@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET003",
@@ -35,10 +37,12 @@
       "event_guests": [],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         },
         {
-          "user": "https://api.calendly.com/users/U102"
+          "user": "https://api.calendly.com/users/U102",
+          "user_email": "user_U102@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET002",

--- a/test/testdata/scheduled_events_002_page2.json
+++ b/test/testdata/scheduled_events_002_page2.json
@@ -11,10 +11,12 @@
       "event_guests": [],
       "event_memberships": [
         {
-          "user": "https://api.calendly.com/users/U001"
+          "user": "https://api.calendly.com/users/U001",
+          "user_email": "user_U001@email.com"
         },
         {
-          "user": "https://api.calendly.com/users/U101"
+          "user": "https://api.calendly.com/users/U101",
+          "user_email": "user_U101@email.com"
         }
       ],
       "event_type": "https://api.calendly.com/event_types/ET001",


### PR DESCRIPTION
Although we already have the user UUID in the membership object, which corresponds to the user ID in Calendly, adding the email allows me to identify the user in my database who created or is responsible for that event.