### PR TITLE
Support either UUIDs or URIs in client

### DIFF
--- a/lib/calendly/client.rb
+++ b/lib/calendly/client.rb
@@ -84,9 +84,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.1
-    def user(uuid = 'me')
-      check_not_empty uuid, 'uuid'
-      body = request :get, "users/#{uuid}"
+    def user(uuid_or_uri = 'me')
+      uri = to_request_uri(uuid_or_uri) { |uuid| "users/#{uuid}" }
+      body = request :get, uri
       User.new body[:resource], self
     end
 
@@ -98,9 +98,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.4.1
-    def event_type(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "event_types/#{uuid}"
+    def event_type(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "event_types/#{uuid}" }
+      body = request :get, uri
       EventType.new body[:resource], self
     end
 
@@ -197,9 +197,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.3
-    def scheduled_event(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "scheduled_events/#{uuid}"
+    def scheduled_event(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "scheduled_events/#{uuid}" }
+      body = request :get, uri
       Event.new body[:resource], self
     end
 
@@ -244,13 +244,13 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.11.0
-    def cancel_event(uuid, options: nil)
-      check_not_empty uuid, 'uuid'
+    def cancel_event(uuid_or_uri, options: nil)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "scheduled_events/#{uuid}/cancellation" }
 
       opts_keys = %i[reason]
       params = merge_options options, opts_keys
 
-      body = request :post, "scheduled_events/#{uuid}/cancellation", body: params
+      body = request :post, uri, body: params
       InviteeCancellation.new body[:resource], self
     end
 
@@ -297,10 +297,13 @@ module Calendly
     # @raise [Calendly::Error] if the inv_uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.4
-    def event_invitee(ev_uuid, inv_uuid)
-      check_not_empty ev_uuid, 'ev_uuid'
-      check_not_empty inv_uuid, 'inv_uuid'
-      body = request :get, "scheduled_events/#{ev_uuid}/invitees/#{inv_uuid}"
+    def event_invitee(invitee_uri_or_ev_uuid, inv_uuid = nil)
+      check_not_empty invitee_uri_or_ev_uuid, 'invitee_uri_or_ev_uuid'
+      uri = to_request_uri(invitee_uri_or_ev_uuid) do |ev_uuid|
+        check_not_empty inv_uuid, 'inv_uuid'
+        "scheduled_events/#{ev_uuid}/invitees/#{inv_uuid}"
+      end
+      body = request :get, uri
       Invitee.new body[:resource], self
     end
 
@@ -320,12 +323,12 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.4
-    def event_invitees(uuid, options: nil)
-      check_not_empty uuid, 'uuid'
+    def event_invitees(uuid_or_uri, options: nil)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "scheduled_events/#{uuid}/invitees" }
 
       opts_keys = %i[count email page_token sort status]
       params = merge_options options, opts_keys
-      body = request :get, "scheduled_events/#{uuid}/invitees", params: params
+      body = request :get, uri, params: params
 
       items = body[:collection] || []
       evs = items.map { |item| Invitee.new item, self }
@@ -341,9 +344,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.9.0
-    def invitee_no_show(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "invitee_no_shows/#{uuid}"
+    def invitee_no_show(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "invitee_no_shows/#{uuid}" }
+      body = request :get, uri
       InviteeNoShow.new body[:resource], self
     end
 
@@ -442,9 +445,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.5
-    def membership(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "organization_memberships/#{uuid}"
+    def membership(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "organization_memberships/#{uuid}" }
+      body = request :get, uri
       OrganizationMembership.new body[:resource], self
     end
 
@@ -510,9 +513,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.0.7
-    def delete_membership(uuid)
-      check_not_empty uuid, 'uuid'
-      request :delete, "organization_memberships/#{uuid}"
+    def delete_membership(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "organization_memberships/#{uuid}" }
+      request :delete, uri
       true
     end
 
@@ -608,9 +611,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def webhook(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "webhook_subscriptions/#{uuid}"
+    def webhook(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "webhook_subscriptions/#{uuid}" }
+      body = request :get, uri
       WebhookSubscription.new body[:resource], self
     end
 
@@ -709,9 +712,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.1.3
-    def delete_webhook(uuid)
-      check_not_empty uuid, 'uuid'
-      request :delete, "webhook_subscriptions/#{uuid}"
+    def delete_webhook(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "webhook_subscriptions/#{uuid}" }
+      request :delete, uri
       true
     end
 
@@ -723,9 +726,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.12.0
-    def routing_form(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "routing_forms/#{uuid}"
+    def routing_form(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "routing_forms/#{uuid}" }
+      body = request :get, uri
       RoutingForm.new body[:resource], self
     end
 
@@ -764,9 +767,9 @@ module Calendly
     # @raise [Calendly::Error] if the uuid arg is empty.
     # @raise [Calendly::ApiError] if the api returns error code.
     # @since 0.12.0
-    def routing_form_submission(uuid)
-      check_not_empty uuid, 'uuid'
-      body = request :get, "routing_form_submissions/#{uuid}"
+    def routing_form_submission(uuid_or_uri)
+      uri = to_request_uri(uuid_or_uri) { |uuid| "routing_form_submissions/#{uuid}" }
+      body = request :get, uri
       RoutingFormSubmission.new body[:resource], self
     end
 
@@ -829,6 +832,13 @@ module Calendly
     end
 
   private
+
+    def to_request_uri(uuid_or_uri)
+      check_not_empty uuid_or_uri, 'uuid_or_uri'
+      return uuid_or_uri if uuid_or_uri.start_with?('http')
+
+      yield uuid_or_uri
+    end
 
     def request(method, path, params: nil, body: nil)
       debug_log "Request #{method.to_s.upcase} #{API_HOST}/#{path} params:#{params}, body:#{body}"

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -106,8 +106,8 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.user ''
       end
-      assert_required_error proc_arg_is_nil, 'uuid'
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_nil, 'uuid_or_uri'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -152,7 +152,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.event_type ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -395,7 +395,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.scheduled_event ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -557,7 +557,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.cancel_event ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -583,7 +583,7 @@ module Calendly
       proc_inv_uuid_arg_is_empty = proc do
         @client.event_invitee 'EV001', ''
       end
-      assert_required_error proc_ev_uuid_arg_is_empty, 'ev_uuid'
+      assert_required_error proc_ev_uuid_arg_is_empty, 'invitee_uri_or_ev_uuid'
       assert_required_error proc_inv_uuid_arg_is_empty, 'inv_uuid'
     end
 
@@ -643,7 +643,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.event_invitees ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -665,7 +665,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.invitee_no_show ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -826,7 +826,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.membership ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -915,7 +915,7 @@ module Calendly
       proc_arg_is_empty = proc do
         @client.delete_membership ''
       end
-      assert_required_error proc_arg_is_empty, 'uuid'
+      assert_required_error proc_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -1067,7 +1067,7 @@ module Calendly
       proc_uuid_arg_is_empty = proc do
         @client.webhook ''
       end
-      assert_required_error proc_uuid_arg_is_empty, 'uuid'
+      assert_required_error proc_uuid_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -1308,7 +1308,7 @@ module Calendly
       proc_uuid_arg_is_empty = proc do
         @client.delete_webhook ''
       end
-      assert_required_error proc_uuid_arg_is_empty, 'uuid'
+      assert_required_error proc_uuid_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -1328,7 +1328,7 @@ module Calendly
       proc_uuid_arg_is_empty = proc do
         @client.routing_form ''
       end
-      assert_required_error proc_uuid_arg_is_empty, 'uuid'
+      assert_required_error proc_uuid_arg_is_empty, 'uuid_or_uri'
     end
 
     #
@@ -1409,7 +1409,7 @@ module Calendly
       proc_uuid_arg_is_empty = proc do
         @client.routing_form_submission ''
       end
-      assert_required_error proc_uuid_arg_is_empty, 'uuid'
+      assert_required_error proc_uuid_arg_is_empty, 'uuid_or_uri'
     end
 
     #


### PR DESCRIPTION
In many places in the Calendly API and webhook payloads, a URI to a resource is returned. However, the client in this gem always expects a UUID, which  forces users to either parse the URI and extract the relevant UUID parts, or use the model objects (an API which involves more boilerplate).

```rb
# Supposing, you have a Calendly invitee object; the old_invitee field is a URI

invitee_uri = invitee.old_invitee

# To fetch the old invitee, you can't do this:

Calendly::Client.new.event_invitee(invitee_uri) # <= doesn't work

# You can either write a regex to extract the UUIDs from the URI
event_uuid, invitee_uuid = /https:\/\/api\.calendly\.com\/scheduled_events\/(.+)\/invitees\/(.+)/.match(invitee_uri)
Calendly::Client.new.event_invitee(event_uuid, invitee_uuid)


# or (unnecessary boilerplate, must remember to `#fetch`)

Calendly::Invitee.new({ uri: invitee_uri }, Calendly::Client.new).fetch
```

This PR makes most of the client methods also accept URIs, while keeping backwards compatibility.