### PR TITLE
Remove requirement for passing client to models

### DIFF
--- a/lib/calendly/models/model_utils.rb
+++ b/lib/calendly/models/model_utils.rb
@@ -23,7 +23,7 @@ module Calendly
     # @raise [Calendly::Error] if the client is nil.
     # @since 0.1.0
     def client
-      raise Error.new('@client is not ready.') if !@client || !@client.is_a?(Client)
+      @client = Client.new if !@client || !@client.is_a?(Client)
 
       @client
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1549,7 +1549,7 @@ module Calendly
       assert_required_error proc_owner_type_arg_is_empty, 'owner_type'
     end
 
-  private
+    private
 
     def add_refresh_token_stub_request(is_valid: true)
       req_params = {

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -11,19 +11,12 @@ module Calendly
       @ev_uri = "#{HOST}/scheduled_events/#{@ev_uuid}"
       attrs = {uri: @ev_uri}
       @event = Event.new attrs, @client
-      @event_no_client = Event.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @event.inspect.start_with? '#<Calendly::Event:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @event_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_event
       res_body = load_test_data 'scheduled_event_001.json'
@@ -48,13 +41,6 @@ module Calendly
 
       invitee_cancel = @event.cancel options: req_body
       assert_invitee_cancel002 invitee_cancel
-    end
-
-    def test_that_it_returns_an_error_client_is_not_ready_on_cancel
-      proc_client_is_blank = proc do
-        @event_no_client.cancel
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
     end
 
     def test_that_it_returns_event_invitees_in_single_page

--- a/test/models/event_type_test.rb
+++ b/test/models/event_type_test.rb
@@ -11,19 +11,12 @@ module Calendly
       @et_uri = "#{HOST}/event_types/#{@et_uuid}"
       attrs = {uri: @et_uri}
       @event_type = EventType.new attrs, @client
-      @event_type_no_client = EventType.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @event_type.inspect.start_with? '#<Calendly::EventType:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @event_type_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_invitee
       res_body = load_test_data 'event_type_001_user.json'

--- a/test/models/invitee_no_show_test.rb
+++ b/test/models/invitee_no_show_test.rb
@@ -11,19 +11,12 @@ module Calendly
       @no_show_uri = "#{HOST}/invitee_no_shows/#{@no_show_uuid}"
       attrs = {uri: @no_show_uri}
       @no_show = InviteeNoShow.new attrs, @client
-      @no_show_no_client = InviteeNoShow.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @no_show.inspect.start_with? '#<Calendly::InviteeNoShow:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @no_show_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_invitee_no_show
       res_body = load_test_data 'no_show_001.json'

--- a/test/models/invitee_test.rb
+++ b/test/models/invitee_test.rb
@@ -14,7 +14,6 @@ module Calendly
       @inv_uri = "#{event_uri}/invitees/#{@inv_uuid}"
       attrs = {uri: @inv_uri, event: event_uri}
       @invitee = Invitee.new attrs, @client
-      @invitee_no_client = Invitee.new attrs
 
       @invitee_no_show = Invitee.new attrs, @client
       @no_show_uuid = 'NO_SHOW002'
@@ -26,12 +25,6 @@ module Calendly
       assert @invitee.inspect.start_with? '#<Calendly::Invitee:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @invitee_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_invitee
       res_body = load_test_data 'scheduled_event_invitee_301.json'

--- a/test/models/organization_invitation_test.rb
+++ b/test/models/organization_invitation_test.rb
@@ -13,18 +13,10 @@ module Calendly
       @inv_uri = "#{org_uri}/invitations/#{@inv_uuid}"
       attrs = {uri: @inv_uri, organization: org_uri}
       @inv = OrganizationInvitation.new attrs, @client
-      @inv_no_client = OrganizationInvitation.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @inv.inspect.start_with? '#<Calendly::OrganizationInvitation:'
-    end
-
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @inv_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
     end
 
     def test_that_it_returns_an_associated_invitation

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -13,18 +13,10 @@ module Calendly
       @user_uri = "#{HOST}/users/U001"
       attrs = {uri: @mem_uri, organization: @org_uri, user: @user_uri}
       @mem = OrganizationMembership.new attrs, @client
-      @mem_no_client = OrganizationMembership.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @mem.inspect.start_with? '#<Calendly::OrganizationMembership:'
-    end
-
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @mem_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
     end
 
     def test_that_it_returns_an_associated_membership

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -12,18 +12,10 @@ module Calendly
       @org_params = {organization: @org_uri}
       attrs = {uri: @org_uri}
       @org = Organization.new attrs, @client
-      @org_no_client = Organization.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @org.inspect.start_with? '#<Calendly::Organization:'
-    end
-
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @org_no_client.memberships
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
     end
 
     def test_that_it_returns_memberships_in_single_page

--- a/test/models/routing_form_submission_test.rb
+++ b/test/models/routing_form_submission_test.rb
@@ -12,19 +12,12 @@ module Calendly
       @submission_params = {form: @submission_uri}
       attrs = {uri: @submission_uri}
       @submission = RoutingFormSubmission.new attrs, @client
-      @submission_no_client = RoutingFormSubmission.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @submission.inspect.start_with? '#<Calendly::RoutingFormSubmission:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @submission_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_submission
       res_body = load_test_data 'routing_form_submission_001.json'

--- a/test/models/routing_form_test.rb
+++ b/test/models/routing_form_test.rb
@@ -12,19 +12,12 @@ module Calendly
       @form_params = {form: @form_uri}
       attrs = {uri: @form_uri}
       @form = RoutingForm.new attrs, @client
-      @form_no_client = RoutingForm.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @form.inspect.start_with? '#<Calendly::RoutingForm:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @form_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_routing_form
       res_body = load_test_data 'routing_form_001.json'

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -11,7 +11,6 @@ module Calendly
       @team_uri = "#{HOST}/teams/#{@team_uuid}"
       attrs = {uri: @team_uri}
       @team = Team.new attrs, @client
-      @team_no_client = Team.new attrs
     end
 
     def test_it_returns_inspect_string

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -14,19 +14,12 @@ module Calendly
       @user_params = {user: @user_uri}
       attrs = {uri: @user_uri, current_organization: @org_uri}
       @user = User.new attrs, @client
-      @user_no_client = User.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @user.inspect.start_with? '#<Calendly::User:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @user_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_user
       res_body = load_test_data 'user_001.json'

--- a/test/models/webhook_subscription_test.rb
+++ b/test/models/webhook_subscription_test.rb
@@ -11,19 +11,12 @@ module Calendly
       @webhook_uri = "#{HOST}/webhook_subscriptions/#{@webhook_uuid}"
       attrs = {uri: @webhook_uri}
       @webhook = WebhookSubscription.new attrs, @client
-      @webhook_no_client = WebhookSubscription.new attrs
     end
 
     def test_it_returns_inspect_string
       assert @webhook.inspect.start_with? '#<Calendly::WebhookSubscription:'
     end
 
-    def test_that_it_returns_an_error_client_is_not_ready
-      proc_client_is_blank = proc do
-        @webhook_no_client.fetch
-      end
-      assert_error proc_client_is_blank, '@client is not ready.'
-    end
 
     def test_that_it_returns_an_associated_webhook
       res_body = load_test_data 'webhook_organization_001.json'


### PR DESCRIPTION
As pointed out in https://github.com/koshilife/calendly-api-ruby-client/pull/65, when you need to initialize a model, you must pass a client instance, or else you'll get an error "client is not ready":

```rb
Calendly::Event.new({ uri: }).fetch # raises an error
```

But there's no value to this error–to avoid it, you just need to add a boilerplate client, which is easy to forget, annoying and pointless:

```rb
Calendly::Event.new({ uri: }, Calendly::Client.new).fetch
```

This PR gets rid of this requirement. If no client is passed, a new client instance is created. It's what the user does most times anyway.